### PR TITLE
Fixing bugs in preparation for demo

### DIFF
--- a/tango_simlib/examples/override_class.py
+++ b/tango_simlib/examples/override_class.py
@@ -150,6 +150,8 @@ class OverrideVds(object):
         quant_camera_power_on.set_val(camera_power_state_value, model.time_func())
 
         if camera_power_state[data_input.lower()]:
+            for quantity in model.sim_quantities.values():
+                quantity.default_val(model.time_func())
             tango_dev.set_state(DevState.ON)
         else:
             for quantity in model.sim_quantities.values():

--- a/tango_simlib/quantities.py
+++ b/tango_simlib/quantities.py
@@ -146,5 +146,8 @@ class ConstantQuantity(Quantity):
     def next_val(self, t):
         return self.last_val
 
+    def default_val(self, t):
+        self.last_val = True
+
 
 register_quantity_class(ConstantQuantity)

--- a/tango_simlib/sim_xmi_parser.py
+++ b/tango_simlib/sim_xmi_parser.py
@@ -658,9 +658,6 @@ class PopulateModelQuantities(object):
                 model_attr_props = attr_props
             else:
                 model_attr_props.update(attr_props)
-                quantity = self.sim_model.sim_quantities[attr_name]
-                quantity.meta = model_attr_props
-                return
 
             if model_attr_props.has_key('quantity_type'):
                 if model_attr_props['quantity_type'] in ['ConstantQuantity']:

--- a/tango_simlib/tests/MkatVds.xmi
+++ b/tango_simlib/tests/MkatVds.xmi
@@ -86,15 +86,6 @@
       </argout>
       <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
     </commands>
-    <commands name="TrapUpdate" description="Update trap. this request is called by a script." execMethod="trap_update" displayLevel="OPERATOR" polledPeriod="0" isDynamic="false">
-      <argin description="trap : tuple (Trap update from a script (8, `on`))">
-        <type xsi:type="pogoDsl:StringType"/>
-      </argin>
-      <argout description="">
-        <type xsi:type="pogoDsl:VoidType"/>
-      </argout>
-      <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
-    </commands>
     <commands name="Zoom" description="Zoom camera to a specified direction or specified position." execMethod="zoom" displayLevel="OPERATOR" polledPeriod="0" isDynamic="false">
       <argin description="zoom_direction : string (zoom to the specific direction), zoom_position (optional) : int (zoom to the specific position)">
         <type xsi:type="pogoDsl:VoidType"/>
@@ -129,14 +120,6 @@
       <dataReadyEvent fire="false" libCheckCriteria="true"/>
       <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
       <properties description="Camera power status" label="camera-power-on" unit="" standardUnit="" displayUnit="" format="" maxValue="" minValue="" maxAlarm="" minAlarm="" maxWarning="" minWarning="" deltaTime="" deltaValue=""/>
-    </attributes>
-    <attributes name="device_status" attType="Scalar" rwType="READ" displayLevel="OPERATOR" polledPeriod="3000" maxX="" maxY="" allocReadMember="true" isDynamic="false">
-      <dataType xsi:type="pogoDsl:StringType"/>
-      <changeEvent fire="false" libCheckCriteria="false"/>
-      <archiveEvent fire="false" libCheckCriteria="false"/>
-      <dataReadyEvent fire="false" libCheckCriteria="true"/>
-      <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
-      <properties description="Overall status of the video display system" label="device-status" unit="" standardUnit="" displayUnit="" format="" maxValue="" minValue="" maxAlarm="" minAlarm="" maxWarning="" minWarning="" deltaTime="" deltaValue=""/>
     </attributes>
     <attributes name="flood_lights_on" attType="Scalar" rwType="READ" displayLevel="OPERATOR" polledPeriod="3000" maxX="" maxY="" allocReadMember="true" isDynamic="false">
       <dataType xsi:type="pogoDsl:BooleanType"/>

--- a/tango_simlib/tests/MkatVds_SIMDD.json
+++ b/tango_simlib/tests/MkatVds_SIMDD.json
@@ -8,12 +8,6 @@
       },
       {
           "basicAttributeData": {
-              "name": "device_status",
-              "quantity_type": "ConstantQuantity"
-          }
-      },
-      {
-          "basicAttributeData": {
               "name": "flood_lights_on",
               "quantity_type": "ConstantQuantity"
           }
@@ -198,22 +192,6 @@
                 "input_parameters": {
                     "dtype_in": "Void",
                     "doc_in": "",
-                    "dformat_in": "Scalar"
-                },
-                "output_parameters": {
-                    "dtype_out": "Void",
-                    "doc_out": "",
-                    "dformat_out": "Scalar"
-                }
-	    }
-        },
-    	{
-            "basicCommandData": {
-                "name": "TrapUpdate",
-                "description": "Update trap. This request is called by a script.",
-                "input_parameters": {
-                    "dtype_in": "String",
-                    "doc_in": "trap : tuple (trap update from a script (8, 'on'))",
                     "dformat_in": "Scalar"
                 },
                 "output_parameters": {

--- a/tango_simlib/tests/test_simdd_json_parser.py
+++ b/tango_simlib/tests/test_simdd_json_parser.py
@@ -473,14 +473,13 @@ class test_SimddDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase):
                                'value'), 2), data_in)
 
 
-MKAT_VDS_ATTRIBUTE_LIST = frozenset(['camera_power_on', 'device_status',
-                                     'flood_lights_on', 'focus_position',
-                                     'pan_position', 'pdu_connected',
+MKAT_VDS_ATTRIBUTE_LIST = frozenset(['camera_power_on', 'flood_lights_on',
+                                     'focus_position', 'pan_position', 'pdu_connected',
                                      'ptz_controller_connected', 'snmpd_trap_running',
                                      'tilt_position', 'zoom_position'])
 MKAT_VDS_COMMAND_LIST = frozenset(['CameraPowerOn', 'FloodLightOn', 'Focus', 'Pan',
                                    'PresetClear', 'PresetGoto', 'PresetSet', 'Stop',
-                                   'Tilt', 'TrapUpdate', 'Zoom'])
+                                   'Tilt', 'Zoom'])
 
 class test_XmiSimddDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase):
 


### PR DESCRIPTION
**sim_xmi_parser.py**: In the _setup_sim_quantities_ method, we were only changing the meta information of the quantity but not changing the type of _Quantity_ instance to assign based on the value of the _quantity_type_ captured in the _SIMDD_ file.
**override_class.py**: Modified the _action_camerapoweron_ method to set the quantity values back to their defualt values when the device is commanded to turn on.
**quantities.py**: Added a new method in the _ConstantQuantity_ class that resets the quantities' values to default values.
**MkatVds.xmi**:Removed the _TrapUpdate_ and the _device_status_ command and attribute information, respectively. They are more appropriate for _KATCP_ devices.
**MkatVds_SIMDD.json**: Removed the _TrapUpdate_ and _device_status_ command and attribute information, respectively. They are more appropriate for _KATCP_ devices.
**test_simdd_json_parser.py**: Updated test cases appropriately.