### PR TITLE
User/lize/updates

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,7 +33,7 @@ setup(name="tango_simlib",
           },
       zip_safe=False,
       include_package_data=True,
-      package_data={'tango_simlib': ['tests/*.xmi', 'tests/*.json']},
+      package_data={'tango_simlib': ['SIMDD.schema', 'tests/*.xmi', 'tests/*.json']},
       dependency_links=[
           'git+https://github.com/vxgmichel/pytango-devicetest.git#egg=python_devicetest'],
       entry_points={

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -426,8 +426,8 @@ def generate_device_server(server_name, sim_data_files, directory=''):
              '    TangoDeviceServers = get_tango_device_server(model, sim_data_files)',
              '    server_run(TangoDeviceServers)',
              '\nif __name__ == "__main__":',
-             '    main()']
-    with open(os.path.join(directory, "%s.py" % server_name), 'w') as dserver:
+             '    main()\n']
+    with open(os.path.join(directory, "%s" % server_name), 'w') as dserver:
         dserver.write('\n'.join(lines))
 
 def get_device_class(sim_data_files):

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -17,6 +17,7 @@ import os
 import weakref
 import logging
 import argparse
+import time
 
 from PyTango import Attr, AttrWriteType, UserDefaultAttrProp, AttrQuality, Database
 from PyTango.server import Device, DeviceMeta, command, attribute
@@ -420,6 +421,7 @@ def generate_device_server(server_name, sim_data_files, directory=''):
              'from PyTango.server import server_run',
              ('from tango_simlib.tango_sim_generator import ('
               'configure_device_model, get_tango_device_server)'),
+             '\n\n# File generated on {} by tango-simlib-tango-simulator-generator'.format(time.ctime()),
              '\n\ndef main():',
              '    sim_data_files = %s' % sim_data_files,
              '    model = configure_device_model(sim_data_files)',

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -429,6 +429,8 @@ def generate_device_server(server_name, sim_data_files, directory=''):
              '    main()\n']
     with open(os.path.join(directory, "%s" % server_name), 'w') as dserver:
         dserver.write('\n'.join(lines))
+    # Make the script executable
+    os.chmod(os.path.join(directory, "%s" % server_name), 477)
 
 def get_device_class(sim_data_files):
     """Get device class name from specified xmi/simdd description file
@@ -474,13 +476,14 @@ def get_argparser():
     required_argument('--sim-data-file', action='append',
                       help='Simulator description data files(s) '
                       '.i.e. can specify multiple files')
+    required_argument('--directory', help='TANGO server executable path', default='')
     required_argument('--dserver-name', help='TANGO server executable command')
     return parser
 
 def main():
     arg_parser = get_argparser()
     opts = arg_parser.parse_args()
-    generate_device_server(opts.dserver_name, opts.sim_data_file)
+    generate_device_server(opts.dserver_name, opts.sim_data_file, directory=opts.directory)
 
 if __name__ == "__main__":
     main()

--- a/tango_simlib/tests/test_sim_test_interface.py
+++ b/tango_simlib/tests/test_sim_test_interface.py
@@ -275,7 +275,7 @@ class test_TangoSimGenDeviceIntegration(ClassCleanupUnittestMixin, unittest.Test
                 server_name, server_instance, '%scontrol' % device_name,
                 database_filename, '%sSimControl' % cls.sim_device_class,
                 sim_test_device_prop)
-        cls.sub_proc = subprocess.Popen(["python", "{}/{}.py".format(
+        cls.sub_proc = subprocess.Popen(["python", "{}/{}".format(
                                             cls.temp_dir, server_name),
                                         server_instance, "-file={}".format(
                                             database_filename),

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -6,7 +6,7 @@ import pkg_resources
 
 from devicetest import TangoTestContext
 
-from katcore.testutils import cleanup_tempfile
+from tango_simlib.testutils import cleanup_tempfile
 from katcp.testutils import start_thread_with_cleanup
 from tango_simlib.testutils import ClassCleanupUnittestMixin
 from tango_simlib import model, sim_xmi_parser, tango_sim_generator, helper_module

--- a/tango_simlib/tests/test_simdd_json_parser.py
+++ b/tango_simlib/tests/test_simdd_json_parser.py
@@ -7,7 +7,7 @@ import pkg_resources
 
 from devicetest import TangoTestContext
 
-from katcore.testutils import cleanup_tempfile
+from tango_simlib.testutils import cleanup_tempfile
 from katcp.testutils import start_thread_with_cleanup
 from tango_simlib import simdd_json_parser, helper_module
 from tango_simlib import sim_xmi_parser, model

--- a/tango_simlib/tests/test_tango_sim_generator.py
+++ b/tango_simlib/tests/test_tango_sim_generator.py
@@ -45,7 +45,7 @@ class test_TangoSimGenDeviceIntegration(ClassCleanupUnittestMixin, unittest.Test
                 server_name, server_instance, '%scontrol' % device_name,
                 database_filename, '%sSimControl' % cls.sim_device_class,
                 sim_test_device_prop)
-        cls.sub_proc = subprocess.Popen(["python", "{}/{}.py".format(
+        cls.sub_proc = subprocess.Popen(["python", "{}/{}".format(
                                             cls.temp_dir, server_name),
                                         server_instance, "-file={}".format(
                                             database_filename),

--- a/tango_simlib/testutils.py
+++ b/tango_simlib/testutils.py
@@ -5,6 +5,7 @@ import shutil
 import tempfile
 import sys
 import errno
+import os
 
 LOGGER = logging.getLogger(__name__)
 


### PR DESCRIPTION
- remove .py extension from --dserver-name 
-- add executable rights to the --dserver-name after file has been generated in tango-simlib-tango-simulator-generator
- added --directory for the dserver-name
- changed katcamconfig/base-simulators to use DishElementMaster-DS instead of tango-simlib-dish-element-master-DS
- Added SIMDD.schema to package data

TODO - assume pkg_data directory for sim-data-files if the file as specified is not found

Needs [katcamconfig PR#233](https://github.com/ska-sa/katcamconfig/pull/233)

Use as follows:
```
cd ~/svn/tango-simlib
sudo tango-simlib-tango-simulator-generator --sim-data-file /home/kat/svn/tango-simlib/tango_simlib/tests/DishElementMaster.xmi --sim-data-file /home/kat/svn/tango-simlib/tango_simlib/tests/DishElementMaster_SIMDD.json --dserver-name DishElementMaster-DS --directory /usr/local/bin/

```