### PR TITLE
User/athanaseus/allow starting of device server using short notation

### DIFF
--- a/tango_simlib/helper_module.py
+++ b/tango_simlib/helper_module.py
@@ -65,7 +65,7 @@ def get_server_name():
     arguments passed, where sys.argv[1] is the server instance.
 
     """
-    executable_name = os.path.split(sys.argv[0].split('.')[0])[1]
+    executable_name = os.path.split(sys.argv[0])[1].split('.')[0]
     server_name = executable_name + '/' + sys.argv[1]
     return server_name
 

--- a/tango_simlib/helper_module.py
+++ b/tango_simlib/helper_module.py
@@ -65,7 +65,7 @@ def get_server_name():
     arguments passed, where sys.argv[1] is the server instance.
 
     """
-    executable_name = os.path.split(sys.argv[0])[1].split('.')[0]
+    executable_name = os.path.split(sys.argv[0])[-1].split('.')[0]
     server_name = executable_name + '/' + sys.argv[1]
     return server_name
 


### PR DESCRIPTION
We get device server name from command line arguments during start-up, thus the case of `./server-name instance` was not handled.