### PR TITLE
Handling error raised when creating Attr instance

### DIFF
--- a/tango_simlib/helper_module.py
+++ b/tango_simlib/helper_module.py
@@ -6,7 +6,8 @@ from PyTango import Database
 
 
 DEFAULT_TANGO_DEVICE_COMMANDS = frozenset(['State', 'Status', 'Init'])
-DEFAULT_TANGO_DEVICE_ATTRIBUTES = frozenset(['State', 'Status'])
+DEFAULT_TANGO_DEVICE_ATTRIBUTES = frozenset(['State', 'Status', 'AttributesNotAdded',
+                                             'NumAttributesNotAdded'])
 SIM_CONTROL_ADDITIONAL_IMPLEMENTED_ATTR = set([
     'Status',            # Tango library attribute
     'State',             # Tango library attribute

--- a/tango_simlib/sim_xmi_parser.py
+++ b/tango_simlib/sim_xmi_parser.py
@@ -443,15 +443,22 @@ class XmiParser(object):
         if arg_type == 'State':
             return CmdArgType.DevState
         try:
+            # Substituting the 'Int' type with 'Long'. 'DevInt' is not a supported
+            # data type in TANGO.
+            if arg_type == 'Int':
+                arg_type = 'Long'
+            elif arg_type == 'UInt':
+                arg_type = 'ULong'
+            elif arg_type == 'IntArray':
+                arg_type = 'LongArray'
+            elif arg_type == 'UIntArray':
+                arg_type = 'ULongArray'
+
             # The DevVarTypeArray data type specified in pogo writes
             # TypeArray in xmi file instead
-            if arg_type in ['FloatArray', 'DoubleArray', 'StringArray']:
+            if arg_type in ['FloatArray', 'DoubleArray', 'StringArray', 'LongArray', 'ULongArray']:
                 arg_type = getattr(PyTango, 'DevVar' + arg_type)
             else:
-                # Substituting the 'Int' type with 'Long'. 'DevInt' is not a supported
-                # data type in TANGO.
-                if arg_type == 'Int':
-                    arg_type = 'Long'
                 arg_type = getattr(PyTango, 'Dev' + arg_type)
         except AttributeError:
             MODULE_LOGGER.debug("PyTango has no attribute 'Dev{}".format(arg_type))

--- a/tango_simlib/sim_xmi_parser.py
+++ b/tango_simlib/sim_xmi_parser.py
@@ -28,6 +28,12 @@ POGO_PYTANGO_ATTR_FORMAT_TYPES_MAP = {
     'Scalar': AttrDataFormat.SCALAR,
     'Spectrum': AttrDataFormat.SPECTRUM}
 
+INT_TYPE_MAP = {
+    'Int': 'Long',
+    'UInt': 'ULong',
+    'IntArray': 'LongArray',
+    'UIntArray': 'ULongArray'
+    }
 # TODO(KM 31-10-2016): Need to add xmi attributes' properties that are currently
 # not being handled by the parser e.g. [displayLevel, enumLabels] etc.
 POGO_USER_DEFAULT_ATTR_PROP_MAP = {
@@ -536,14 +542,10 @@ class XmiParser(object):
         try:
             # Substituting the 'Int' type with 'Long'. 'DevInt' is not a supported
             # data type in TANGO.
-            if arg_type == 'Int':
-                arg_type = 'Long'
-            elif arg_type == 'UInt':
-                arg_type = 'ULong'
-            elif arg_type == 'IntArray':
-                arg_type = 'LongArray'
-            elif arg_type == 'UIntArray':
-                arg_type = 'ULongArray'
+            try:
+                arg_type = INT_TYPE_MAP[arg_type]
+            except KeyError:
+                MODULE_LOGGER.info("arg_type {} is not an integer type.".format(arg_type)
 
             # The DevVarTypeArray data type specified in pogo writes
             # TypeArray in xmi file instead

--- a/tango_simlib/sim_xmi_parser.py
+++ b/tango_simlib/sim_xmi_parser.py
@@ -528,8 +528,9 @@ class XmiParser(object):
         # For now it will be treated as normal DevString type
         if arg_type.find('Const') != -1:
             arg_type = arg_type.replace('Const', '')
-        # The out_type of the device State command is PyTango._PyTango.CmdArgType.DevState
-        # instead of the default PyTango.utils.DevState
+        # The out_type of the device State command is
+        # PyTango._PyTango.CmdArgType.DevState instead of the default
+        # PyTango.utils.DevState.
         if arg_type == 'State':
             return CmdArgType.DevState
         try:
@@ -550,7 +551,8 @@ class XmiParser(object):
                             'LongArray', 'ULongArray']:
                 arg_type = getattr(PyTango, 'DevVar' + arg_type)
             elif arg_type in ['FloatVector', 'DoubleVector', 'StringVector']:
-                arg_type = getattr(PyTango, 'DevVar' + arg_type.replace('Vector', 'Array'))
+                arg_type = (
+                    getattr(PyTango, 'DevVar' + arg_type.replace('Vector', 'Array')))
             else:
                 arg_type = getattr(PyTango, 'Dev' + arg_type)
         except AttributeError:

--- a/tango_simlib/sim_xmi_parser.py
+++ b/tango_simlib/sim_xmi_parser.py
@@ -448,6 +448,10 @@ class XmiParser(object):
             if arg_type in ['FloatArray', 'DoubleArray', 'StringArray']:
                 arg_type = getattr(PyTango, 'DevVar' + arg_type)
             else:
+                # Substituting the 'Int' type with 'Long'. 'DevInt' is not a supported
+                # data type in TANGO.
+                if arg_type == 'Int':
+                    arg_type = 'Long'
                 arg_type = getattr(PyTango, 'Dev' + arg_type)
         except AttributeError:
             MODULE_LOGGER.debug("PyTango has no attribute 'Dev{}".format(arg_type))

--- a/tango_simlib/sim_xmi_parser.py
+++ b/tango_simlib/sim_xmi_parser.py
@@ -345,7 +345,7 @@ class XmiParser(object):
         command_data['argoutDescription'] = output_parameter.attrib['description']
         command_data['argoutType'] = self._get_arg_type(output_parameter)
         command_data['inherited'] = (
-                description_data.find('status').attrib['inherited'])
+            description_data.find('status').attrib['inherited'])
         return command_data
 
     def extract_attributes_description_data(self, description_data):
@@ -422,12 +422,12 @@ class XmiParser(object):
             attribute_data['dynamicAttributes']['attType'] = (
                 POGO_PYTANGO_ATTR_FORMAT_TYPES_MAP[attType])
 
-        attribute_data['dynamicAttributes']['maxX'] = (1
-                if attribute_data['dynamicAttributes']['maxX'] == ''
-                else int(attribute_data['dynamicAttributes']['maxX']))
-        attribute_data['dynamicAttributes']['maxY'] = (0
-                if attribute_data['dynamicAttributes']['maxY'] == ''
-                else int(attribute_data['dynamicAttributes']['maxY']))
+        attribute_data['dynamicAttributes']['maxX'] = (
+            1 if attribute_data['dynamicAttributes']['maxX'] == ''
+            else int(attribute_data['dynamicAttributes']['maxX']))
+        attribute_data['dynamicAttributes']['maxY'] = (
+            0 if attribute_data['dynamicAttributes']['maxY'] == ''
+            else int(attribute_data['dynamicAttributes']['maxY']))
 
         attribute_data['dynamicAttributes']['dataType'] = (
             self._get_arg_type(description_data))
@@ -441,7 +441,7 @@ class XmiParser(object):
         attribute_data['properties'] = description_data.find('properties').attrib
         attribute_data['properties']['inherited'] = (
             description_data.find('status').attrib['inherited'])
-        
+
         try:
             attribute_data['eventCriteria'] = description_data.find(
                 'eventCriteria').attrib
@@ -455,7 +455,7 @@ class XmiParser(object):
         except AttributeError:
             MODULE_LOGGER.info(
                 "No archive event(s) information was captured in the XMI file.")
-        
+
         return attribute_data
 
     def extract_property_description_data(self, description_data, property_group):
@@ -490,14 +490,14 @@ class XmiParser(object):
         property_data = dict()
         property_data[property_group] = description_data.attrib.copy()
         property_data[property_group]['type'] = (
-                self._get_arg_type(description_data))
+            self._get_arg_type(description_data))
         property_data[property_group]['inherited'] = (
-                description_data.find('status').attrib['inherited'])
+            description_data.find('status').attrib['inherited'])
         try:
             default_prop_values = description_data.findall('DefaultPropValue')
             default_values = [prop_value.text for prop_value in default_prop_values]
             property_data[property_group]['DefaultPropValue'] = (
-                    default_values if default_values else "")
+                default_values if default_values else "")
         except KeyError:
             MODULE_LOGGER.info("%s has no default value(s) specified", property_group)
         except AttributeError:
@@ -545,12 +545,13 @@ class XmiParser(object):
             try:
                 arg_type = INT_TYPE_MAP[arg_type]
             except KeyError:
-                MODULE_LOGGER.info("arg_type {} is not an integer type.".format(arg_type)
+                MODULE_LOGGER.info("arg_type {} is not an integer type.".
+                                   format(arg_type))
 
             # The DevVarTypeArray data type specified in pogo writes
-            # TypeArray in xmi file instead
-            if arg_type in ['FloatArray', 'DoubleArray', 'StringArray',
-                            'LongArray', 'ULongArray']:
+            # TypeArray in xmi file instead.
+            if arg_type in ['FloatArray', 'DoubleArray', 'StringArray', 'LongArray',
+                            'ULongArray']:
                 arg_type = getattr(PyTango, 'DevVar' + arg_type)
             elif arg_type in ['FloatVector', 'DoubleVector', 'StringVector']:
                 arg_type = (
@@ -696,7 +697,7 @@ class XmiParser(object):
 
         for properties_info in props:
             properties[properties_info[property_group]['name']] = (
-                    properties_info[property_group])
+                properties_info[property_group])
 
         return properties
 

--- a/tango_simlib/sim_xmi_parser.py
+++ b/tango_simlib/sim_xmi_parser.py
@@ -456,7 +456,8 @@ class XmiParser(object):
 
             # The DevVarTypeArray data type specified in pogo writes
             # TypeArray in xmi file instead
-            if arg_type in ['FloatArray', 'DoubleArray', 'StringArray', 'LongArray', 'ULongArray']:
+            if arg_type in ['FloatArray', 'DoubleArray', 'StringArray',
+                            'LongArray', 'ULongArray']:
                 arg_type = getattr(PyTango, 'DevVar' + arg_type)
             else:
                 arg_type = getattr(PyTango, 'Dev' + arg_type)

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -254,7 +254,6 @@ def get_tango_device_server(model, sim_data_files):
             super(TangoDeviceServer, self).init_device()
             self.model = model
             self._not_added_attributes = []
-            self._not_added_attributes_num = 0
             self._reset_to_default_state()
 
         def _reset_to_default_state(self):

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -281,9 +281,10 @@ def get_tango_device_server(model, sim_data_files):
                 meta_data = model_sim_quants[attribute_name].meta
                 attr_dtype = meta_data['data_type']
                 d_format = meta_data['data_format']
-                # Dynamically add all attributes except those with DevEnum data type
-                # and SPECTRUM data format since they are added statically to the
-                # device class prior to start-up.
+                # Dynamically add all attributes except those with DevEnum data type,
+                # and SPECTRUM data format since they are added statically to the device
+                # class prior to start-up. Also exclude attributes with a data format
+                # 'IMAGE' as we currently do not handle them.
                 if str(attr_dtype) == 'DevEnum':
                     continue
                 elif str(d_format) == 'SPECTRUM':

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -299,8 +299,7 @@ def get_tango_device_server(model, sim_data_files):
                         attr = Attr(attribute_name, attr_dtype, rw_type)
                     except Exception as e:
                         self._not_added_attributes.append(attribute_name)
-                        self._not_added_attributes_num += 1
-                        MODULE_LOGGER.info("Attribut %s could not be added dynamically"
+                        MODULE_LOGGER.info("Attribute %s could not be added dynamically"
                                            " due to an error raised %s.", attribute_name,
                                            str(e))
                         continue
@@ -326,7 +325,7 @@ def get_tango_device_server(model, sim_data_files):
         @attribute(dtype=int, doc="Number of attributes not added to the device due "
                    "to an error.")
         def NumAttributesNotAdded(self):
-            return self._not_added_attributes_num
+            return len(self._not_added_attributes)
 
     class SimControl(TangoTestDeviceServerBase, TangoTestDeviceServerCommands,
                      TangoTestDeviceServerStaticAttrs):

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -253,6 +253,8 @@ def get_tango_device_server(model, sim_data_files):
         def init_device(self):
             super(TangoDeviceServer, self).init_device()
             self.model = model
+            self._not_added_attributes = []
+            self._not_added_attributes_num = 0
             self._reset_to_default_state()
 
         def _reset_to_default_state(self):
@@ -281,13 +283,31 @@ def get_tango_device_server(model, sim_data_files):
                 # Dynamically add all attributes except those with DevEnum data type
                 # and SPECTRUM data format since they are added statically to the
                 # device class prior to start-up.
-                if str(attr_dtype) != 'DevEnum' and str(d_format) != 'SPECTRUM':
+                print 'attr_dtype ', attr_dtype
+                print 'd_format ', d_format
+                #if str(attr_dtype) == 'DevEnum':
+                #    print attribute_name
+                #    pass
+                #elif str(d_format) in ['SPECTRUM', 'IMAGE']:
+                #    print attribute_name
+                #    pass
+                #else:
+                #    print attribute_name
+                if str(attr_dtype) != 'DevEnum' and (str(d_format) != 'SPECTRUM' and str(d_format) != 'IMAGE'):
                     # The return value of rwType is a string and it is required as a
                     # PyTango data type when passed to the Attr function.
                     # e.g. 'READ' -> PyTango.AttrWriteType.READ
                     rw_type = meta_data['writable']
                     rw_type = getattr(AttrWriteType, rw_type)
-                    attr = Attr(attribute_name, attr_dtype, rw_type)
+                    # Add a try/except clause when creating an instance of Attr class
+                    # as PyTango may raise an error when things go wrong.
+                    print attribute_name
+                    try:
+                        attr = Attr(attribute_name, attr_dtype, rw_type)
+                    except Exception as e:
+                        self._not_added_attributes.append(attribute_name)
+                        self._not_added_attributes_num += 1
+                        print str(e)
                     attr_props = UserDefaultAttrProp()
                     for prop in meta_data.keys():
                         attr_prop_setter = getattr(attr_props, 'set_' + prop, None)
@@ -300,6 +320,17 @@ def get_tango_device_server(model, sim_data_files):
                     self.add_attribute(attr, self.read_attributes)
                     MODULE_LOGGER.info("Added dynamic {} attribute"
                                        .format(attribute_name))
+
+        @attribute(dtype=(str,), doc="List of attributes that were not added to the "
+                   "device due to an error.",
+                   max_dim_x=10000)
+        def AttributesNotAdded(self):
+            return self._not_added_attributes
+
+        @attribute(dtype=int, doc="Number of attributes not added to the device due "
+                   "to an error.")
+        def NumAttributesNotAdded(self):
+            return self._not_added_attributes_num
 
     class SimControl(TangoTestDeviceServerBase, TangoTestDeviceServerCommands,
                      TangoTestDeviceServerStaticAttrs):

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -284,7 +284,10 @@ def get_tango_device_server(model, sim_data_files):
                 # device class prior to start-up.
                 if str(attr_dtype) == 'DevEnum':
                     continue
-                elif str(d_format) in ['SPECTRUM', 'IMAGE']:
+                elif str(d_format) == 'SPECTRUM':
+                    continue
+                elif str(d_format) == 'IMAGE':
+                    self._not_added_attributes.append(attribute_name)
                     continue
                 else:
                     # The return value of rwType is a string and it is required as a

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -300,8 +300,8 @@ def get_tango_device_server(model, sim_data_files):
                     except Exception as e:
                         self._not_added_attributes.append(attribute_name)
                         self._not_added_attributes_num += 1
-                        MODULE_LOGGER.info("Attribute %s could not be added dynamically "
-                                           " due to an error raised %s." attribute_name,
+                        MODULE_LOGGER.info("Attribut %s could not be added dynamically"
+                                           " due to an error raised %s.", attribute_name,
                                            str(e))
                         continue
                     attr_props = UserDefaultAttrProp()

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -283,17 +283,11 @@ def get_tango_device_server(model, sim_data_files):
                 # Dynamically add all attributes except those with DevEnum data type
                 # and SPECTRUM data format since they are added statically to the
                 # device class prior to start-up.
-                print 'attr_dtype ', attr_dtype
-                print 'd_format ', d_format
-                #if str(attr_dtype) == 'DevEnum':
-                #    print attribute_name
-                #    pass
-                #elif str(d_format) in ['SPECTRUM', 'IMAGE']:
-                #    print attribute_name
-                #    pass
-                #else:
-                #    print attribute_name
-                if str(attr_dtype) != 'DevEnum' and (str(d_format) != 'SPECTRUM' and str(d_format) != 'IMAGE'):
+                if str(attr_dtype) == 'DevEnum':
+                    continue
+                elif str(d_format) in ['SPECTRUM', 'IMAGE']:
+                    continue
+                else:
                     # The return value of rwType is a string and it is required as a
                     # PyTango data type when passed to the Attr function.
                     # e.g. 'READ' -> PyTango.AttrWriteType.READ
@@ -301,13 +295,15 @@ def get_tango_device_server(model, sim_data_files):
                     rw_type = getattr(AttrWriteType, rw_type)
                     # Add a try/except clause when creating an instance of Attr class
                     # as PyTango may raise an error when things go wrong.
-                    print attribute_name
                     try:
                         attr = Attr(attribute_name, attr_dtype, rw_type)
                     except Exception as e:
                         self._not_added_attributes.append(attribute_name)
                         self._not_added_attributes_num += 1
-                        print str(e)
+                        MODULE_LOGGER.info("Attribute %s could not be added dynamically "
+                                           " due to an error raised %s." attribute_name,
+                                           str(e))
+                        continue
                     attr_props = UserDefaultAttrProp()
                     for prop in meta_data.keys():
                         attr_prop_setter = getattr(attr_props, 'set_' + prop, None)

--- a/tango_simlib/tests/Weather.xmi
+++ b/tango_simlib/tests/Weather.xmi
@@ -54,6 +54,23 @@
       </argout>
       <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
     </commands>
+    <commands name="cmd1" description="" execMethod="cmd1" displayLevel="OPERATOR" polledPeriod="0" isDynamic="false">
+      <argin description="">
+        <type xsi:type="pogoDsl:IntArrayType"/>
+      </argin>
+      <argout description="">
+        <type xsi:type="pogoDsl:VoidType"/>
+      </argout>
+      <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
+    </commands>
+    <attributes name="integer2" attType="Scalar" rwType="READ" displayLevel="OPERATOR" polledPeriod="1000" maxX="" maxY="" allocReadMember="false" isDynamic="false">
+      <dataType xsi:type="pogoDsl:UIntType"/>
+      <changeEvent fire="false" libCheckCriteria="false"/>
+      <archiveEvent fire="false" libCheckCriteria="false"/>
+      <dataReadyEvent fire="false" libCheckCriteria="true"/>
+      <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
+      <properties description="" label="integer2" unit="" standardUnit="" displayUnit="" format="" maxValue="" minValue="" maxAlarm="" minAlarm="" maxWarning="" minWarning="" deltaTime="" deltaValue=""/>
+    </attributes>
     <attributes name="image1" attType="Image" rwType="READ" displayLevel="OPERATOR" polledPeriod="0" maxX="4" maxY="4" allocReadMember="true" isDynamic="false">
       <dataType xsi:type="pogoDsl:DoubleType"/>
       <changeEvent fire="false" libCheckCriteria="false"/>
@@ -141,6 +158,14 @@
       <properties description="Wind speed in central telescope area." label="Wind speed" unit="m/s" standardUnit="" displayUnit="" format="" maxValue="30" minValue="0" maxAlarm="25" minAlarm="" maxWarning="15" minWarning="" deltaTime="" deltaValue=""/>
       <eventCriteria relChange="10" absChange="0.5" period="1000"/>
       <evArchiveCriteria relChange="10" absChange="0.5" period="1000"/>
+    </dynamicAttributes>
+    <dynamicAttributes name="integer1" attType="Scalar" rwType="READ" displayLevel="OPERATOR" polledPeriod="1000" maxX="" maxY="" allocReadMember="true" isDynamic="true">
+      <dataType xsi:type="pogoDsl:IntType"/>
+      <changeEvent fire="false" libCheckCriteria="false"/>
+      <archiveEvent fire="false" libCheckCriteria="false"/>
+      <dataReadyEvent fire="false" libCheckCriteria="true"/>
+      <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
+      <properties description="An attribute with a `DevInt` data type." label="integer1" unit="" standardUnit="" displayUnit="" format="" maxValue="" minValue="" maxAlarm="" minAlarm="" maxWarning="" minWarning="" deltaTime="" deltaValue=""/>
     </dynamicAttributes>
     <preferences docHome="./doc_html" makefileHome="/usr/share/pogo/preferences"/>
   </classes>

--- a/tango_simlib/tests/Weather.xmi
+++ b/tango_simlib/tests/Weather.xmi
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="ASCII"?>
 <pogoDsl:PogoSystem xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:pogoDsl="http://www.esrf.fr/tango/pogo/PogoDsl">
   <classes name="Weather" pogoRevision="9.1">
-    <description description="" title="" sourcePath="/home/athanaseus/Documents/SKA_Software_Engeneering/TANGO/pogo" language="Python" filestogenerate="XMI   file,Protected Regions" license="GPL" copyright="" hasMandatoryProperty="true" hasConcreteProperty="true" hasAbstractCommand="false" hasAbstractAttribute="false">
+    <description description="" title="" sourcePath="/home/kat/svn/tango-simlib/tango_simlib/tests" language="Python" filestogenerate="XMI   file,Protected Regions" license="GPL" copyright="" hasMandatoryProperty="true" hasConcreteProperty="true" hasAbstractCommand="false" hasAbstractAttribute="false">
       <inheritances classname="Device_Impl" sourcePath=""/>
       <identification contact="at ska.ac.za - aramaila" author="aramaila" emailDomain="ska.ac.za" classFamily="Simulators" siteSpecific="" platform="Unix Like" bus="Ethernet" manufacturer="none" reference=""/>
     </description>
@@ -54,6 +54,14 @@
       </argout>
       <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
     </commands>
+    <attributes name="image1" attType="Image" rwType="READ" displayLevel="OPERATOR" polledPeriod="0" maxX="4" maxY="4" allocReadMember="true" isDynamic="false">
+      <dataType xsi:type="pogoDsl:DoubleType"/>
+      <changeEvent fire="false" libCheckCriteria="false"/>
+      <archiveEvent fire="false" libCheckCriteria="false"/>
+      <dataReadyEvent fire="false" libCheckCriteria="true"/>
+      <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
+      <properties description="" label="image1" unit="" standardUnit="" displayUnit="" format="" maxValue="" minValue="" maxAlarm="" minAlarm="" maxWarning="" minWarning="" deltaTime="" deltaValue=""/>
+    </attributes>
     <dynamicAttributes name="temperature" attType="Scalar" rwType="READ" displayLevel="OPERATOR" polledPeriod="1000" maxX="" maxY="" allocReadMember="true" isDynamic="true">
       <dataType xsi:type="pogoDsl:DoubleType"/>
       <changeEvent fire="true" libCheckCriteria="false"/>

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -195,8 +195,8 @@ expected_sim_xmi_file_device_property_info = {
     'inherited': 'false'}
 
 EXPECTED_QUANTITIES_LIST = ['insolation', 'temperature', 'pressure', 'rainfall',
-                            'relative-humidity', 'wind-direction',
-                            'input-comms-ok', 'wind-speed', 'image1']
+                            'relative-humidity', 'wind-direction', 'integer2',
+                            'input-comms-ok', 'wind-speed', 'image1', 'integer1']
 
 class test_SimXmiDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase):
 
@@ -527,8 +527,7 @@ class test_PopModelActions(GenericSetup):
         device_name = 'tango/device/instance'
         cmd_info = self.xmi_parser.get_reformatted_cmd_metadata()
 
-        sim_model = (model.PopulateModelActions(self.xmi_parser, device_name).
-                     sim_model)
+        sim_model = (model.PopulateModelActions(self.xmi_parser, device_name).sim_model)
         self.assertEqual(len(sim_model.sim_quantities), 0,
                          "The model has some unexpected quantities")
 

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -512,11 +512,11 @@ class test_PopModelActions(GenericSetup):
                                 (cmd_name))
 
 class test_XmiStaticAttributes(ClassCleanupUnittestMixin, unittest.TestCase):
-    """Test the use of xmi to generate a tango simulator.
+    """Test the use of XMI to generate a TANGO simulator.
 
     This class specifically ensures that the devEnum attribute type and
     spectrum data format attributes added statically prior to device start-up
-    are well configured using the specified parameters in the POGO xmi.
+    are well configured using the specified parameters in the POGO XMI.
 
     """
 
@@ -561,16 +561,17 @@ class test_XmiStaticAttributes(ClassCleanupUnittestMixin, unittest.TestCase):
                          "expected list!")
 
     def test_enum_attribute_properties(self):
-        """Test whether the DevEnum attributes are well configred.
+        """Test whether the DevEnum attributes are well configured.
 
         Checks whether the DevEnum data type attribute properties specified
-        in the POGO generated xmi file are added to the TANGO device
+        in the POGO generated XMI file are added to the TANGO device
 
         """
         attr_name = 'adminMode'
         attributes = set(self.device.get_attribute_list())
         self.assertIn(attr_name, attributes,
-                      "The attribute adminMode is not in the device attribute list")
+                      "The attribute {} is not in the device attribute list".
+                      format(attr_name))
         attr_config = self.device.get_attribute_config(attr_name)
         for attr_prop, attr_prop_val in expected_admin_mode_devenum_attr_info.items():
             device_attr_prop_val = getattr(attr_config, attr_prop, None)
@@ -595,30 +596,24 @@ class test_XmiStaticAttributes(ClassCleanupUnittestMixin, unittest.TestCase):
         """Test whether the Spectrum attributes are well configred.
 
         Checks whether the Spectrum data format attribute properties specified
-        in the POGO generated xmi file are added to the TANGO device
+        in the POGO generated XMI file are added to the TANGO device
 
         """
         attr_name = 'achievedPointing'
         attributes = set(self.device.get_attribute_list())
         self.assertIn(attr_name, attributes,
-                      "The attribute adminMode is not in the device attribute list")
+                      "The attribute {} is not in the device attribute list".
+                      format(attr_name))
         attr_config = self.device.get_attribute_config(attr_name)
         for attr_prop, attr_prop_val in (
                 expected_achieved_pointing_spectrum_attr_info.items()):
             device_attr_prop_val = getattr(attr_config, attr_prop, None)
             if device_attr_prop_val:
-                # Tango device return attribute properties with Not pecified
+                # Tango device return attribute properties with 'Not specified'
                 # or No `property name` value if no info is provided
                 if str(device_attr_prop_val) in helper_module.TANGO_NOT_SPECIFIED_PROPS:
                     device_attr_prop_val = ''
-                # In the case of enum labels we assert the set of the lists
-                if type(attr_prop_val) == list:
-                    self.assertEqual(set(device_attr_prop_val), set(attr_prop_val),
-                                     "The expected value for the device property "
-                                     "parameter '%s' does not match with the "
-                                     "actual value" % (attr_prop))
-                else:
-                    self.assertEqual(device_attr_prop_val, attr_prop_val,
-                                     "The expected value for the device property "
-                                     "parameter '%s' does not match with the "
-                                     "actual value" % (attr_prop))
+                self.assertEqual(device_attr_prop_val, attr_prop_val,
+                                 "The expected value for the device property "
+                                 "parameter '%s' does not match with the "
+                                 "actual value" % (attr_prop))

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -194,9 +194,9 @@ expected_sim_xmi_file_device_property_info = {
     'type': PyTango.CmdArgType.DevString,
     'inherited': 'false'}
 
-EXPECTED_QUANTITIES_LIST = ['insolation', 'temperature', 'pressure', 'rainfall',
-                            'relative-humidity', 'wind-direction', 'integer2',
-                            'input-comms-ok', 'wind-speed', 'image1', 'integer1']
+EXPECTED_QUANTITIES_LIST = frozenset([
+    'insolation', 'temperature', 'pressure', 'rainfall', 'relative-humidity',
+    'wind-direction', 'integer2', 'input-comms-ok', 'wind-speed', 'image1', 'integer1'])
 
 class test_SimXmiDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase):
 
@@ -235,7 +235,7 @@ class test_SimXmiDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase)
                          "The attribute {} has been added to the device.".
                          format(attribute_name))
         not_added_attr = self.device.read_attribute('AttributesNotAdded')
-        not_added_attr_names = getattr(not_added_attr, 'value')
+        not_added_attr_names = not_added_attr.value
         self.assertIn(attribute_name, not_added_attr_names,
                       "The attribute {} was not added to the list of attributes that"
                       " could not be added to the device.".format(attribute_name))
@@ -253,9 +253,11 @@ class test_SimXmiDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase)
     def test_attribute_properties(self):
         attribute_list = self.device.get_attribute_list()
         attribute_data = self.xmi_parser.get_reformatted_device_attr_metadata()
+        not_added_attr = self.device.read_attribute('AttributesNotAdded')
+        not_added_attr_names = not_added_attr.value
 
         for attr_name, attr_metadata in attribute_data.items():
-            if attr_name == 'image1':
+            if attr_name in not_added_attr_names:
                 continue
             self.assertIn(attr_name, attribute_list,
                           "Device does not have the attribute %s" % (attr_name))

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -441,7 +441,7 @@ class test_XmiParser(GenericSetup):
 
         """
         actual_parsed_cmds = self.xmi_parser.get_reformatted_cmd_metadata()
-        expected_cmd_list = ['On', 'Off', 'Add'] + default_pogo_commands
+        expected_cmd_list = ['On', 'Off', 'Add', 'cmd1'] + default_pogo_commands
         actual_parsed_cmd_list = actual_parsed_cmds.keys()
         self.assertGreater(len(actual_parsed_cmd_list), len(default_pogo_commands),
                            "There are missing commands in the parsed list")

--- a/tango_simlib/tests/test_simdd_json_parser.py
+++ b/tango_simlib/tests/test_simdd_json_parser.py
@@ -303,7 +303,7 @@ class test_SimddDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase):
         """
         attributes = set(self.device.get_attribute_list())
         expected_attributes = []
-        default_attributes = {'State', 'Status'}
+        default_attributes = helper_module.DEFAULT_TANGO_DEVICE_ATTRIBUTES
         expected_attributes = (
             self.simdd_json_parser.get_reformatted_device_attr_metadata().keys())
 
@@ -453,7 +453,7 @@ class test_XmiSimddDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCas
 
         """
         attributes = set(self.device.get_attribute_list())
-        default_attributes = {'State', 'Status'}
+        default_attributes = helper_module.DEFAULT_TANGO_DEVICE_ATTRIBUTES
         self.assertEqual(MKAT_VDS_ATTRIBUTE_LIST, attributes - default_attributes,
                          "Actual tango device attribute list differs from expected "
                          "list! \n\n Missing attributes: \n {}".format(

--- a/tango_simlib/tests/test_tango_sim_generator.py
+++ b/tango_simlib/tests/test_tango_sim_generator.py
@@ -74,15 +74,29 @@ class test_TangoSimGenDeviceIntegration(ClassCleanupUnittestMixin, unittest.Test
                      'attribute_name').enum_labels)
 
     def test_device_attribute_list(self):
-        """ Testing whether the attributes specified in the POGO generated xmi file
-        are added to the TANGO device
+        """ Testing whether the attributes specified in the POGO generated XMI file
+        are added to the TANGO device.
         """
-        attributes = set(self.sim_device.get_attribute_list())
+        # First testing that the attribute with data format "IMAGE" is not in the device.
+        attribute_name = 'image1'
+        device_attributes = set(self.sim_device.get_attribute_list())
+        self.assertNotIn(attribute_name, device_attributes,
+                         "The attribute {} has been added to the device.".
+                         format(attribute_name))
+        not_added_attr = self.sim_device.read_attribute('AttributesNotAdded')
+        not_added_attr_names = getattr(not_added_attr, 'value')
+        self.assertIn(attribute_name, not_added_attr_names,
+                      "The attribute {} was not added to the list of attributes that"
+                      " could not be added to the device.".format(attribute_name))
+
         expected_attributes = []
         default_attributes = helper_module.DEFAULT_TANGO_DEVICE_ATTRIBUTES
+
         for attribute_data in self.xmi_parser.device_attributes:
             expected_attributes.append(attribute_data['dynamicAttributes']['name'])
-        self.assertEqual(set(expected_attributes), attributes - default_attributes,
+
+        self.assertEqual(set(expected_attributes) - set(not_added_attr_names),
+                         device_attributes - default_attributes,
                          "Actual tango device attribute list differs from expected "
                          "list!")
 

--- a/tango_simlib/tests/test_tango_sim_generator.py
+++ b/tango_simlib/tests/test_tango_sim_generator.py
@@ -83,7 +83,7 @@ class test_TangoSimGenDeviceIntegration(ClassCleanupUnittestMixin, unittest.Test
                          "The attribute {} has been added to the device.".
                          format(attribute_name))
         not_added_attr = self.sim_device.read_attribute('AttributesNotAdded')
-        not_added_attr_names = getattr(not_added_attr, 'value')
+        not_added_attr_names = not_added_attr.value
         self.assertIn(attribute_name, not_added_attr_names,
                       "The attribute {} was not added to the list of attributes that"
                       " could not be added to the device.".format(attribute_name))


### PR DESCRIPTION
tango_sim_generator.py: Creating an instance of _Attr_ class results in an error. In this case it seems to occur when an we try to create an attribute with a data_type of _DevInt_.

This is related to a post made by Jimmy on the Tango forum [Data type is not supported](http://www.tango-controls.org/community/forum/c/development/python/tango-simlib-easily-generate-tango-device-simulators/).

The error that results:
```
Exiting: Server exited with PyTango.DevFailed:
DevFailed[
DevError[
    desc = Attribute : Value2:  Data type is not supported
  origin = Attr::check_type
  reason = API_AttrWrongDefined
severity = ERR]
]

Exited
Segmentation fault (core dumped)
```

I also added two additional attributes to keep track on the attributes that do not get added to the device.
I will also create an issue on [PyTango github](https://github.com/tango-controls/pytango)