### PR TITLE
Getting server name iff not testing.

### DIFF
--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -370,10 +370,10 @@ def configure_device_model(sim_data_file=None, test_device_name=None):
 
     """
     data_file = sim_data_file
-    server_name = helper_module.get_server_name()
     klass_name = get_device_class(data_file)
 
     if test_device_name is None:
+        server_name = helper_module.get_server_name()
         db_instance = Database()
         # db_datum is a PyTango.DbDatum structure with attribute name and value_string.
         # The name attribute represents the name of the device server and the


### PR DESCRIPTION
_tango_sim_generator.py_:  The `get_server_name` method takes the command-line arguments to generate the _server_name_.We only need the _server_name_ to query the TANGO config database for the device name registered for that server. However for testing purposes, that is not required as we use a file database.


This PR resolves these error we get when running tests:
```
Traceback (most recent call last):
  File "/home/kat/svn/tango-simlib/tango_simlib/tests/test_tango_sim_generator.py", line 71, in setUp
    self.data_descr_file)
  File "/home/kat/svn/tango-simlib/tango_simlib/tango_sim_generator.py", line 373, in configure_device_model
    server_name = helper_module.get_server_name()
  File "/home/kat/svn/tango-simlib/tango_simlib/helper_module.py", line 69, in get_server_name
    server_name = executable_name + '/' + sys.argv[1]
IndexError: list index out of range
```
