### PR TITLE
User/lize/add scripts

### DIFF
--- a/scripts/DishElementMaster-DS
+++ b/scripts/DishElementMaster-DS
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+from PyTango.server import server_run
+from tango_simlib.tango_sim_generator import (configure_device_model, get_tango_device_server)
+
+
+# File generated on Thu Jul 20 09:19:00 2017 by tango-simlib-generator
+
+
+def main():
+    sim_data_files = ['/home/kat/svn/tango-simlib/tango_simlib/tests/DishElementMaster.xmi', '/home/kat/svn/tango-simlib/tango_simlib/tests/DishElementMaster_SIMDD.json']
+    model = configure_device_model(sim_data_files)
+    TangoDeviceServers = get_tango_device_server(model, sim_data_files)
+    server_run(TangoDeviceServers)
+
+if __name__ == "__main__":
+    main()

--- a/scripts/README
+++ b/scripts/README
@@ -1,0 +1,6 @@
+# iIf you want to use the Device Server startup scripts for the examples included in tango_simlib
+# it needs to be generated with your specific src installation, i.e.:
+# And then: sudo setup install . -U 
+tango-simlib-generator --sim-data-file $SOURCE/tango_simlib/tests/DishElementMaster.xmi --sim-data-file $SOURCE/tango-simlib/tests/DishElementMaster_SIMDD.json --dserver-name DishElementMaster-DS --directory $SORUCE/scripts/
+
+tango-simlib-generator --sim-data-file $SOURCE/tango_simlib/tests/Weather.xmi --sim-data-file $SOURCE/tango-simlib/tests/Weather_SIMDD.json --dserver-name Weather-DS --directory $SOURCE/scripts/

--- a/scripts/Weather-DS
+++ b/scripts/Weather-DS
@@ -3,7 +3,7 @@ from PyTango.server import server_run
 from tango_simlib.tango_sim_generator import (configure_device_model, get_tango_device_server)
 
 
-# File generated on Thu Jul 20 09:33:11 2017 by tango-simlib-generator
+# File generated on Thu Jul 20 10:00:29 2017 by tango-simlib-tango-simulator-generator
 
 
 def main():

--- a/scripts/Weather-DS
+++ b/scripts/Weather-DS
@@ -1,0 +1,16 @@
+#!/usr/bin/env python
+from PyTango.server import server_run
+from tango_simlib.tango_sim_generator import (configure_device_model, get_tango_device_server)
+
+
+# File generated on Thu Jul 20 09:33:11 2017 by tango-simlib-generator
+
+
+def main():
+    sim_data_files = ['/home/kat/svn/tango-simlib/tango_simlib/tests/Weather.xmi', '/home/kat/svn/tango-simlib/tango_simlib/tests/Weather_SIMDD.json']
+    model = configure_device_model(sim_data_files)
+    TangoDeviceServers = get_tango_device_server(model, sim_data_files)
+    server_run(TangoDeviceServers)
+
+if __name__ == "__main__":
+    main()

--- a/setup.py
+++ b/setup.py
@@ -39,6 +39,8 @@ setup(name="tango_simlib",
       package_data={'tango_simlib': ['SIMDD.schema', 'tests/*.xmi', 'tests/*.json']},
       dependency_links=[
           'git+https://github.com/vxgmichel/pytango-devicetest.git#egg=python_devicetest'],
+      scripts=['scripts/DishElementMaster-DS',
+               'scripts/Weather-DS'],
       entry_points={
           'console_scripts': [
               'tango-simlib-generator'


### PR DESCRIPTION
For now, I'm adding the scripts as the script generation is currently the only manual step to run an ska_mid configuration. I explored a mechanism to add the script to the kat-conftemplate as another "launch" string, but that needed sudo rights to land the script in /usr/local/bin as it is done manually.
Will revisit this in the near future - but want to get a coherent ska_mid system going.

(I don't understand why these commits are shown as kmadisa.  It asks me for a git username and password. Must be something with the keys on devlt. Will discuss with Katleho when in the office tomorrow.)