### PR TITLE
Force all unicode attributes in XMI files to byte strings

### DIFF
--- a/tango_simlib/sim_xmi_parser.py
+++ b/tango_simlib/sim_xmi_parser.py
@@ -244,6 +244,14 @@ class XmiParser(object):
         """
         self.data_description_file_name = sim_xmi_file
         tree = ET.parse(sim_xmi_file)
+
+        # ensure all unicode attribute values are converted to byte strings
+        # as TANGO does not handle unicode
+        for child in tree.findall('.//'):
+            for key, value in child.attrib.items():
+                if isinstance(value, unicode):
+                    child.attrib[key] = value.encode('ascii', 'replace')
+
         self._tree = tree
         root = tree.getroot()
         device_class = root.find('classes')

--- a/tango_simlib/tests/Weather.xmi
+++ b/tango_simlib/tests/Weather.xmi
@@ -105,7 +105,7 @@
       <archiveEvent fire="true" libCheckCriteria="false"/>
       <dataReadyEvent fire="true" libCheckCriteria="true"/>
       <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
-      <properties description="Barometric pressure in central telescope area." label="Barometric pressure" unit="mbar" standardUnit="" displayUnit="" format="" maxValue="1100" minValue="500" maxAlarm="1000" minAlarm="" maxWarning="900" minWarning="" deltaTime="" deltaValue=""/>
+      <properties description="Barometric pressure in central telescope area (unicode: &#x2018;quoted&#x2019;)." label="Barometric pressure" unit="mbar" standardUnit="" displayUnit="" format="" maxValue="1100" minValue="500" maxAlarm="1000" minAlarm="" maxWarning="900" minWarning="" deltaTime="" deltaValue=""/>
       <eventCriteria relChange="10" absChange="0.5" period="1000"/>
       <evArchiveCriteria relChange="10" absChange="0.5" period="1000"/>
     </dynamicAttributes>

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -81,7 +81,9 @@ expected_pressure_attr_info = {
     'data_type': PyTango.CmdArgType.DevDouble,
     'period': '1000',
     'writable': 'READ',
-    'description': 'Barometric pressure in central telescope area.',
+    # The description in the XMI file has unicode quote characters around the word
+    # 'quoted', each must be replaced by a question mark
+    'description': 'Barometric pressure in central telescope area (unicode: ?quoted?).',
     'label': 'Barometric pressure',
     'unit': 'mbar',
     'standard_unit': '',


### PR DESCRIPTION
Some of the XMI files generated by POGO have unicode description strings.  TANGO doesn't do unicode which causes device server startup to fail.  Workaround is to force all attributes to be byte strings immediately after parsing the XMI file.  This will result in question marks replacing the unicode characters.

This addresses issue: #57

Suggest using this PR instead of #58.