### PR TITLE
Removing unmaintained python-devicetest dependency.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,8 +28,7 @@ setup(name="tango_simlib",
       tests_require=[
           'enum',
           'numpy',
-          'nose_xunitmp',
-          'python-devicetest'],
+          'nose_xunitmp'],
       extras_require={
           'docs': ["sphinx-pypi-upload",
                    "numpydoc",
@@ -38,8 +37,6 @@ setup(name="tango_simlib",
       zip_safe=False,
       include_package_data=True,
       package_data={'tango_simlib': ['SIMDD.schema', 'tests/*.xmi', 'tests/*.json']},
-      dependency_links=[
-          'git+https://github.com/vxgmichel/pytango-devicetest.git#egg=python_devicetest'],
       scripts=['scripts/DishElementMaster-DS',
                'scripts/Weather-DS'],
       entry_points={

--- a/tango_simlib/helper_module.py
+++ b/tango_simlib/helper_module.py
@@ -2,7 +2,7 @@ import os
 import sys
 import socket
 
-from PyTango import Database
+from tango import Database
 
 
 DEFAULT_TANGO_DEVICE_COMMANDS = frozenset(['State', 'Status', 'Init'])

--- a/tango_simlib/main.py
+++ b/tango_simlib/main.py
@@ -13,7 +13,7 @@ import sys
 import logging
 import threading
 
-from PyTango.server import server_run
+from tango.server import server_run
 
 from tango_simlib.sim_test_interface import TangoTestDeviceServerBase
 

--- a/tango_simlib/model.py
+++ b/tango_simlib/model.py
@@ -15,7 +15,7 @@ import importlib
 from functools import partial
 from tango_simlib import quantities
 
-from PyTango import (DevBoolean, DevString, DevEnum,
+from tango import (DevBoolean, DevString, DevEnum,
                      DevDouble, DevFloat, DevLong, DevVoid)
 
 

--- a/tango_simlib/sim_sdd_xml_parser.py
+++ b/tango_simlib/sim_sdd_xml_parser.py
@@ -14,7 +14,7 @@ import xml.etree.ElementTree as ET
 
 from tango_simlib.base_parser import Parser
 
-from PyTango import DevDouble, DevLong, DevBoolean, DevString
+from tango import DevDouble, DevLong, DevBoolean, DevString
 
 SDD_MP_PARAMS_TANGO_MAP = {
     'name': 'name',

--- a/tango_simlib/sim_test_interface.py
+++ b/tango_simlib/sim_test_interface.py
@@ -11,12 +11,8 @@
 """
 import weakref
 
-from PyTango import UserDefaultAttrProp
-from PyTango import DevState
-from PyTango import Attr, AttrWriteType
-from PyTango import DevDouble
-from PyTango.server import Device, DeviceMeta
-from PyTango.server import attribute, device_property
+from tango import Attr, AttrWriteType, DevDouble, DevState, UserDefaultAttrProp
+from tango.server import attribute, Device, device_property, DeviceMeta
 
 from tango_simlib import model
 

--- a/tango_simlib/sim_xmi_parser.py
+++ b/tango_simlib/sim_xmi_parser.py
@@ -15,11 +15,9 @@ import logging
 
 import xml.etree.ElementTree as ET
 
-from base_parser import Parser
-import PyTango
+from tango import AttrDataFormat, CmdArgType, DevBoolean, DevEnum, DevString
 
-from PyTango import (DevBoolean, DevString, DevEnum, AttrDataFormat,
-                     CmdArgType)
+from tango_simlib.base_parser import Parser
 
 MODULE_LOGGER = logging.getLogger(__name__)
 CONSTANT_DATA_TYPES = frozenset([DevBoolean, DevEnum, DevString])
@@ -414,15 +412,15 @@ class XmiParser(Parser):
         else:
             pogo_type = description_data.find('type').attrib.values()[0]
         # pogo_type has format -> pogoDsl:DoubleType
-        # Pytango type must be of the form DevDouble
+        # tango type must be of the form DevDouble
         arg_type = pogo_type.split(':')[1].replace('Type', '')
         # pogo_type for status turns out to be 'pogoDsl:ConstStringType
         # For now it will be treated as normal DevString type
         if arg_type.find('Const') != -1:
             arg_type = arg_type.replace('Const', '')
         # The out_type of the device State command is
-        # PyTango._PyTango.CmdArgType.DevState instead of the default
-        # PyTango.utils.DevState.
+        # tango._tango.CmdArgType.DevState instead of the default
+        # tango.utils.DevState.
         if arg_type == 'State':
             return CmdArgType.DevState
         try:
@@ -438,17 +436,18 @@ class XmiParser(Parser):
             # TypeArray in xmi file instead.
             if arg_type in ['FloatArray', 'DoubleArray', 'StringArray', 'LongArray',
                             'ULongArray']:
-                arg_type = getattr(PyTango, 'DevVar' + arg_type)
+                arg_type = getattr(CmdArgType, 'DevVar' + arg_type)
             elif arg_type in ['FloatVector', 'DoubleVector', 'StringVector']:
                 arg_type = (
-                    getattr(PyTango, 'DevVar' + arg_type.replace('Vector', 'Array')))
+                    getattr(CmdArgType, 'DevVar' + arg_type.replace('Vector', 'Array')))
             else:
-                arg_type = getattr(PyTango, 'Dev' + arg_type)
+                arg_type = getattr(CmdArgType, 'Dev' + arg_type)
         except AttributeError:
-            MODULE_LOGGER.debug("PyTango has no attribute 'Dev{}'".format(arg_type))
-            raise AttributeError("PyTango has no attribute 'Dev{}'.\n Try replacing"
-                                 " '{}' with 'Var{}' in the configuration file"
-                                 .format(*(3*(arg_type,))))
+            MODULE_LOGGER.debug(
+                "tango.utils.CmdArgType has no attribute 'Dev{}'".format(arg_type))
+            raise AttributeError(
+                "tango.utils.CmdArgType has no attribute 'Dev{}'.\n Try replacing"
+                " '{}' with 'Var{}' in the configuration file".format(*(3*(arg_type,))))
 
         return arg_type
 

--- a/tango_simlib/simdd_json_parser.py
+++ b/tango_simlib/simdd_json_parser.py
@@ -13,12 +13,12 @@ containing the information needed to instantiate a useful device simulator.
 import logging
 import json
 import pkg_resources
-
-from PyTango._PyTango import CmdArgType, AttrDataFormat
 from jsonschema import validate
 
+from tango import CmdArgType, AttrDataFormat
+
 from tango_simlib import helper_module
-from base_parser import Parser
+from tango_simlib.base_parser import Parser
 
 MODULE_LOGGER = logging.getLogger(__name__)
 EXPECTED_SIMULATION_PARAMETERS = {
@@ -103,8 +103,8 @@ class SimddParser(Parser):
                         'unit': '',
                         'label': '',
                         'description': '',
-                        'data_type': '<PyTango._PyTango.CmdArgType>',
-                        'data_format': '<PyTango._PyTango.AttrDataFormat>',
+                        'data_type': '<tango._tango.CmdArgType>',
+                        'data_format': '<tango._tango.AttrDataFormat>',
                         'delta_t': '',
                         'delta_val': '',
                         'data_shape': {
@@ -299,11 +299,10 @@ class SimddParser(Parser):
                     property_key = str(item[0])
                     # Since the data type specified in the SIMDD is a string format
                     # e.g. String, it is require in Tango device as a CmdArgType
-                    # i.e. PyTango._PyTango.CmdArgType.DevString
+                    # i.e. tango._tango.CmdArgType.DevString
                     if property_key in ['dtype_in', 'dtype_out']:
-                        # Here we extract the cmdArgType obect since
-                        # for later when creating a Tango command,
-                        # data type is required in this format.
+                        # Here we extract the CmdArgType object since for later when
+                        # creating a Tango command, data type is required in this format.
                         val = getattr(CmdArgType, 'Dev%s' % str(item[1]))
                         formated_info[property_key] = val
                     elif property_key in ['dformat_in', 'dformat_out']:
@@ -321,12 +320,11 @@ class SimddParser(Parser):
                 formated_info['actions'] = actions
             else:
                 # Since the data type specified in the SIMDD is a string format
-                # e.g. Double, it is require in Tango device as a CmdArgType
-                # i.e. PyTango._PyTango.CmdArgType.DevDouble
+                # e.g. Double, it is required in Tango device as a CmdArgType
+                # i.e. tango._tango.CmdArgType.DevDouble
                 if str(param_name) in ['data_type']:
-                    # Here we extract the cmdArgType obect since
-                    # for later when creating a Tango attibute,
-                    # data type is required in this format.
+                    # Here we extract the CmdArgType object since for later when creating
+                    # a Tango attibute, data type is required in this format.
                     val = getattr(CmdArgType, 'Dev%s' % str(param_val))
                 elif str(param_name) in ['DefaultPropValue']:
                     # Default property value can be an string, number and array

--- a/tango_simlib/tango_launcher.py
+++ b/tango_simlib/tango_launcher.py
@@ -17,10 +17,10 @@ Helps by auto-registering a TANGO device if needed
 import os
 import sys
 import argparse
-
-import PyTango
-
 from functools import partial
+
+import tango
+
 
 parser = argparse.ArgumentParser(
     description="Launch a TANGO device, handling registration as needed. "
@@ -44,18 +44,18 @@ parser.add_argument('--put-device-property', action='append', help=
                     dest='device_properties', default=[])
 
 def register_device(name, device_class, server_name, instance):
-    dev_info = PyTango.DbDevInfo()
+    dev_info = tango.DbDevInfo()
     dev_info.name = name
     dev_info._class = device_class
     dev_info.server = "{}/{}".format(server_name.split('.')[0], instance)
     print """Attempting to register TANGO device {!r}
     class: {!r}  server: {!r}.""".format(
             dev_info.name, dev_info._class, dev_info.server)
-    db = PyTango.Database()
+    db = tango.Database()
     db.add_device(dev_info)
 
 def put_device_property(dev_name, property_name, property_value):
-    db = PyTango.Database()
+    db = tango.Database()
     print "Setting device {!r} property {!r}: {!r}".format(
         dev_name, property_name, property_value)
     db.put_device_property(dev_name, {property_name:[property_value]})

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -21,18 +21,18 @@ import time
 
 from functools import partial
 
-from PyTango import Attr, AttrWriteType, UserDefaultAttrProp, AttrQuality, Database
-from PyTango.server import Device, DeviceMeta, command, attribute
-from PyTango import DevState, AttrDataFormat, CmdArgType
+from tango import (Attr, AttrDataFormat, AttrQuality, AttrWriteType, CmdArgType,
+                     Database, DevState, UserDefaultAttrProp)
+from tango.server import attribute, Device, DeviceMeta, command
 
-from tango_simlib.model import Model
+from tango_simlib import helper_module
+from tango_simlib.model import (Model, PopulateModelActions, PopulateModelProperties,
+                                PopulateModelQuantities)
 from tango_simlib.sim_xmi_parser import XmiParser
 from tango_simlib.simdd_json_parser import SimddParser
 from tango_simlib.sim_sdd_xml_parser import SDDParser
 from tango_simlib.sim_test_interface import TangoTestDeviceServerBase
-from tango_simlib.model import PopulateModelQuantities, PopulateModelActions
-from tango_simlib.model import PopulateModelProperties
-from tango_simlib import helper_module
+
 
 MODULE_LOGGER = logging.getLogger(__name__)
 
@@ -295,7 +295,7 @@ def get_tango_device_server(model, sim_data_files):
                 else:
                     # The return value of rwType is a string and it is required as a
                     # PyTango data type when passed to the Attr function.
-                    # e.g. 'READ' -> PyTango.AttrWriteType.READ
+                    # e.g. 'READ' -> tango._tango.AttrWriteType.READ
                     rw_type = meta_data['writable']
                     rw_type = getattr(AttrWriteType, rw_type)
                     # Add a try/except clause when creating an instance of Attr class
@@ -466,7 +466,7 @@ def generate_device_server(server_name, sim_data_files, directory=''):
 
     """
     lines = ['#!/usr/bin/env python',
-             'from PyTango.server import server_run',
+             'from tango.server import server_run',
              ('from tango_simlib.tango_sim_generator import ('
               'configure_device_model, get_tango_device_server)'),
              '\n\n# File generated on {} by tango-simlib-generator'.format(time.ctime()),

--- a/tango_simlib/tests/test_dish.py
+++ b/tango_simlib/tests/test_dish.py
@@ -3,15 +3,16 @@ import unittest
 import pkg_resources
 import mock
 
-from devicetest import TangoTestContext
 from mock import Mock, call
+
+from PyTango import DevFailed
+from tango.test_context import DeviceTestContext
 
 from katcp.testutils import start_thread_with_cleanup
 
 from tango_simlib import tango_sim_generator, model
 from tango_simlib.testutils import ClassCleanupUnittestMixin, cleanup_tempfile
 
-from PyTango import DevFailed
 
 DISH_ELEMENT_MASTER_COMMAND_LIST = frozenset([
     'Capture', 'ConfigureAttenuation', 'ConfigureBand1', 'ConfigureBand2',
@@ -356,9 +357,9 @@ class test_Device(ClassCleanupUnittestMixin, unittest.TestCase):
                                                            cls.device_name)
         cls.TangoDeviceServer = tango_sim_generator.get_tango_device_server(
                 model, cls.data_descr_files)[0]
-        cls.tango_context = TangoTestContext(cls.TangoDeviceServer,
-                                             device_name=cls.device_name,
-                                             db=cls.tango_db)
+        cls.tango_context = DeviceTestContext(cls.TangoDeviceServer,
+                                              device_name=cls.device_name,
+                                              db=cls.tango_db)
         start_thread_with_cleanup(cls, cls.tango_context)
 
     def setUp(self):

--- a/tango_simlib/tests/test_dish.py
+++ b/tango_simlib/tests/test_dish.py
@@ -5,7 +5,7 @@ import mock
 
 from mock import Mock, call
 
-from PyTango import DevFailed
+from tango import DevFailed
 from tango.test_context import DeviceTestContext
 
 from katcp.testutils import start_thread_with_cleanup

--- a/tango_simlib/tests/test_quantities.py
+++ b/tango_simlib/tests/test_quantities.py
@@ -1,6 +1,5 @@
 import time
 import unittest
-
 import mock
 
 from tango_simlib import quantities

--- a/tango_simlib/tests/test_sim_sdd_xml_parser.py
+++ b/tango_simlib/tests/test_sim_sdd_xml_parser.py
@@ -2,11 +2,9 @@ import logging
 import unittest
 import pkg_resources
 
-from PyTango import DevDouble
+from tango import DevDouble
 
-from tango_simlib import sim_sdd_xml_parser
-from tango_simlib import sim_xmi_parser
-from tango_simlib import model
+from tango_simlib import model, sim_sdd_xml_parser, sim_xmi_parser
 
 LOGGER = logging.getLogger(__name__)
 

--- a/tango_simlib/tests/test_sim_test_interface.py
+++ b/tango_simlib/tests/test_sim_test_interface.py
@@ -281,12 +281,10 @@ class test_TangoSimGenDeviceIntegration(ClassCleanupUnittestMixin, unittest.Test
                 server_name, server_instance, '%scontrol' % device_name,
                 database_filename, '%sSimControl' % cls.sim_device_class,
                 sim_test_device_prop)
-        cls.sub_proc = subprocess.Popen(["python", "{}/{}".format(
-                                            cls.temp_dir, server_name),
-                                        server_instance, "-file={}".format(
-                                            database_filename),
-                                        "-ORBendPoint", "giop:tcp::{}".format(
-                                            cls.port)])
+        cls.sub_proc = subprocess.Popen(
+            ["python", "{}/{}".format(cls.temp_dir, server_name),
+             server_instance, "-file={}".format(database_filename),
+             "-ORBendPoint", "giop:tcp::{}".format(cls.port)])
         cls.addCleanupClass(cls.sub_proc.kill)
         # Note that tango demands that connection to the server must
         # be delayed by atleast 1000 ms of device server start up.

--- a/tango_simlib/tests/test_sim_test_interface.py
+++ b/tango_simlib/tests/test_sim_test_interface.py
@@ -272,12 +272,6 @@ class test_TangoSimGenDeviceIntegration(ClassCleanupUnittestMixin, unittest.Test
             cls.temp_dir, server_name)
         sim_device_prop = dict(sim_data_description_file=cls.data_descr_files[0])
         sim_test_device_prop = dict(model_key=device_name)
-        # Cannot create an instance of the DeviceProxy inside the test because the
-        # devicetest module patches it as a side effect at import time. It does
-        # save the original DeviceProxy class in the Patcher singleton, so get it
-        # from there
-        #patcher = devicetest.patch.Patcher()
-        #device_proxy = patcher.ActualDeviceProxy
         tango_sim_generator.generate_device_server(
                 server_name, cls.data_descr_files, cls.temp_dir)
         helper_module.append_device_to_db_file(

--- a/tango_simlib/tests/test_sim_test_interface.py
+++ b/tango_simlib/tests/test_sim_test_interface.py
@@ -7,14 +7,12 @@ import pkg_resources
 from functools import partial
 from mock import Mock
 
-from PyTango import DevState, AttrDataFormat, DeviceProxy
+from tango import DevState, AttrDataFormat, DeviceProxy
 from tango.test_context import DeviceTestContext
 
-from tango_simlib import model, quantities
-from tango_simlib import tango_sim_generator, helper_module
-from tango_simlib.testutils import cleanup_tempfile
-from tango_simlib.testutils import ClassCleanupUnittestMixin, cleanup_tempdir
-
+from tango_simlib import helper_module, model, tango_sim_generator, quantities
+from tango_simlib.testutils import (ClassCleanupUnittestMixin, cleanup_tempdir,
+                                    cleanup_tempfile)
 
 
 class FixtureModel(model.Model):

--- a/tango_simlib/tests/test_sim_test_interface.py
+++ b/tango_simlib/tests/test_sim_test_interface.py
@@ -3,17 +3,19 @@ import time
 import unittest
 import subprocess
 import pkg_resources
-import devicetest
 
 from functools import partial
-from devicetest import DeviceTestCase
 from mock import Mock
+
+from PyTango import DevState, AttrDataFormat, DeviceProxy
+from tango.test_context import DeviceTestContext
 
 from tango_simlib import model, quantities
 from tango_simlib import tango_sim_generator, helper_module
+from tango_simlib.testutils import cleanup_tempfile
 from tango_simlib.testutils import ClassCleanupUnittestMixin, cleanup_tempdir
 
-from PyTango import DevState, AttrDataFormat
+
 
 class FixtureModel(model.Model):
 
@@ -86,7 +88,7 @@ def control_attributes(test_model):
     return control_attributes
 
 
-class test_SimControl(DeviceTestCase):
+class test_SimControl(unittest.TestCase):
     device = None
     properties = dict(model_key='the_test_model')
 
@@ -96,14 +98,24 @@ class test_SimControl(DeviceTestCase):
         # The get_tango_device_server function requires  data file which it uses to
         # extract the device class name. However for this test we don't need  it,
         # hence the use of the dummy sim data file.
+        cls.device_name = 'test/nodb/tangodeviceserver'
         cls.device_klass = tango_sim_generator.get_tango_device_server(
             cls.test_model, ['dummy_sim_data_file.txt'])[-1]
-        cls.device = cls.device_klass
-        super(test_SimControl, cls).setUpClass()
+        cls.tango_context = DeviceTestContext(cls.device_klass,
+                                              device_name=cls.device_name,
+                                              properties=cls.properties)
+        cls.tango_context.start()
+
+    @classmethod
+    def tearDownClass(cls):
+        """Kill the device server."""
+        cls.tango_context.stop()
+
 
     def setUp(self):
         super(test_SimControl, self).setUp()
         self.addCleanup(self.test_model.reset_model)
+        self.device = self.tango_context.device
         self.control_attributes = control_attributes(self.test_model)
         self.attr_name_enum_labels = self.device.attribute_query(
                                           'attribute_name').enum_labels
@@ -264,8 +276,8 @@ class test_TangoSimGenDeviceIntegration(ClassCleanupUnittestMixin, unittest.Test
         # devicetest module patches it as a side effect at import time. It does
         # save the original DeviceProxy class in the Patcher singleton, so get it
         # from there
-        patcher = devicetest.patch.Patcher()
-        device_proxy = patcher.ActualDeviceProxy
+        #patcher = devicetest.patch.Patcher()
+        #device_proxy = patcher.ActualDeviceProxy
         tango_sim_generator.generate_device_server(
                 server_name, cls.data_descr_files, cls.temp_dir)
         helper_module.append_device_to_db_file(
@@ -285,10 +297,10 @@ class test_TangoSimGenDeviceIntegration(ClassCleanupUnittestMixin, unittest.Test
         # Note that tango demands that connection to the server must
         # be delayed by atleast 1000 ms of device server start up.
         time.sleep(1)
-        cls.sim_device = device_proxy(
+        cls.sim_device = DeviceProxy(
                 '%s:%s/test/nodb/tangodeviceserver#dbase=no' % (
                     cls.host, cls.port))
-        cls.sim_control_device = device_proxy(
+        cls.sim_control_device = DeviceProxy(
                 '%s:%s/test/nodb/tangodeviceservercontrol#dbase=no' % (
                     cls.host, cls.port))
 

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -1,17 +1,17 @@
 import mock
 import logging
 import unittest
-
 import pkg_resources
 
-from devicetest import TangoTestContext
+import PyTango
+from tango.test_context import DeviceTestContext
+
+from katcp.testutils import start_thread_with_cleanup
 
 from tango_simlib.testutils import cleanup_tempfile
-from katcp.testutils import start_thread_with_cleanup
 from tango_simlib.testutils import ClassCleanupUnittestMixin
 from tango_simlib import model, sim_xmi_parser, tango_sim_generator, helper_module
 
-import PyTango
 
 LOGGER = logging.getLogger(__name__)
 
@@ -214,7 +214,7 @@ class test_SimXmiDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase)
                                                            cls.device_name)
         cls.TangoDeviceServer = tango_sim_generator.get_tango_device_server(
             model, cls.xmi_file)[0]
-        cls.tango_context = TangoTestContext(cls.TangoDeviceServer,
+        cls.tango_context = DeviceTestContext(cls.TangoDeviceServer,
                                              device_name=cls.device_name,
                                              db=cls.tango_db)
         start_thread_with_cleanup(cls, cls.tango_context)
@@ -564,9 +564,9 @@ class test_XmiStaticAttributes(ClassCleanupUnittestMixin, unittest.TestCase):
                                                            cls.device_name)
         cls.TangoDeviceServer = tango_sim_generator.get_tango_device_server(
             model, cls.xmi_file)[0]
-        cls.tango_context = TangoTestContext(cls.TangoDeviceServer,
-                                             device_name=cls.device_name,
-                                             db=cls.tango_db)
+        cls.tango_context = DeviceTestContext(cls.TangoDeviceServer,
+                                              device_name=cls.device_name,
+                                              db=cls.tango_db)
         start_thread_with_cleanup(cls, cls.tango_context)
 
     def setUp(self):

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -3,7 +3,7 @@ import logging
 import unittest
 import pkg_resources
 
-import PyTango
+import tango
 from tango.test_context import DeviceTestContext
 
 from katcp.testutils import start_thread_with_cleanup
@@ -49,9 +49,9 @@ expected_mandatory_default_cmds_info = [
     {
         "name": 'State',
         "arginDescription": 'none',
-        "arginType": PyTango._PyTango.CmdArgType.DevVoid,
+        "arginType": tango._tango.CmdArgType.DevVoid,
         "argoutDescription": 'Device state',
-        "argoutType": PyTango.utils.DevState,
+        "argoutType": tango.utils.DevState,
         "description": 'This command gets the device state (stored in its '
             'device_state data member) and returns it to the caller.',
         "displayLevel": 'OPERATOR',
@@ -61,9 +61,9 @@ expected_mandatory_default_cmds_info = [
     },
     {
         "arginDescription": 'none',
-        "arginType": PyTango._PyTango.CmdArgType.DevVoid,
+        "arginType": tango._tango.CmdArgType.DevVoid,
         "argoutDescription": 'Device status',
-        "argoutType": PyTango._PyTango.CmdArgType.DevString,
+        "argoutType": tango._tango.CmdArgType.DevString,
         "description": 'This command gets the device status'
             '(stored in its device_status data member) and returns it to the caller.',
         "displayLevel": 'OPERATOR',
@@ -78,7 +78,7 @@ expected_mandatory_default_cmds_info = [
 # parsed by the XmiParser.
 expected_pressure_attr_info = {
     'name': 'pressure',
-    'data_type': PyTango.CmdArgType.DevDouble,
+    'data_type': tango.CmdArgType.DevDouble,
     'period': '1000',
     'writable': 'READ',
     # The description in the XMI file has unicode quote characters around the word
@@ -97,7 +97,7 @@ expected_pressure_attr_info = {
     'min_warning': '',
     'delta_t': '',
     'delta_val': '',
-    'data_format': PyTango.AttrDataFormat.SCALAR,
+    'data_format': tango.AttrDataFormat.SCALAR,
     'max_dim_y': 0,
     'max_dim_x': 1,
     'abs_change': '0.5',
@@ -116,12 +116,12 @@ expected_admin_mode_devenum_attr_info = {
     'archive_abs_change': '1',
     'archive_period': '',
     'archive_rel_change': '',
-    'data_type': PyTango.CmdArgType.DevEnum,
+    'data_type': tango.CmdArgType.DevEnum,
     'delta_t': '',
     'delta_val': '',
     'description': ('Report the current admin mode of the DSH Element. '
                     'Factory defaut is MAINTENANCE.'),
-    'data_format': PyTango.AttrDataFormat.SCALAR,
+    'data_format': tango.AttrDataFormat.SCALAR,
     'display_unit': '',
     'enum_labels': [
         'ONLINE',
@@ -145,14 +145,14 @@ expected_admin_mode_devenum_attr_info = {
     'rel_change': '',
     'standard_unit': '',
     'unit': '',
-    'writable': PyTango.AttrWriteType.READ_WRITE,
+    'writable': tango.AttrWriteType.READ_WRITE,
     'inherited': 'false'}
 
 
 expected_achieved_pointing_spectrum_attr_info = {
     'abs_change': '',
-    'data_format': PyTango._PyTango.AttrDataFormat.SPECTRUM,
-    'data_type': PyTango._PyTango.CmdArgType.DevFloat,
+    'data_format': tango._tango.AttrDataFormat.SPECTRUM,
+    'data_type': tango._tango.CmdArgType.DevFloat,
     'delta_t': '',
     'delta_val': '',
     'description': ('The achieved pointing of the DSH Element. '
@@ -175,16 +175,16 @@ expected_achieved_pointing_spectrum_attr_info = {
     'rel_change': '',
     'standard_unit': '',
     'unit': '[ms, degree, degree]',
-    'writable': PyTango.AttrWriteType.READ_WRITE,
+    'writable': tango.AttrWriteType.READ_WRITE,
     'inherited': 'false'}
 
 # The desired information for the 'On' command when the Weather.xmi file is parsed
 expected_on_cmd_info = {
     'name': 'On',
     'doc_in': 'No input parameter',
-    'dtype_in': PyTango.CmdArgType.DevVoid,
+    'dtype_in': tango.CmdArgType.DevVoid,
     'doc_out': 'Command responds',
-    'dtype_out': PyTango.CmdArgType.DevVoid,
+    'dtype_out': tango.CmdArgType.DevVoid,
     'inherited': 'false'}
 
 # The expected information that would be obtained for the device property when the
@@ -193,7 +193,7 @@ expected_sim_xmi_file_device_property_info = {
     'name': 'sim_xmi_description_file',
     'mandatory': 'true',
     'description': 'Path to the pogo generated xmi file',
-    'type': PyTango.CmdArgType.DevString,
+    'type': tango.CmdArgType.DevString,
     'inherited': 'false'}
 
 EXPECTED_QUANTITIES_LIST = frozenset([
@@ -274,7 +274,7 @@ class test_SimXmiDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase)
                 attr_prop_value = getattr(attr_query_data, attr_parameter, None)
                 # Here the writable property is checked for, since Pogo
                 # expresses in as a string (e.g. 'READ') where tango device return a
-                # Pytango object `PyTango.AttrWriteType.READ` and taking
+                # tango object `tango._tango.AttrWriteType.READ` and taking
                 # its string returns 'READ' which corresponds to the Pogo one.
                 if attr_parameter in ['writable']:
                     attr_prop_value = str(attr_prop_value)

--- a/tango_simlib/tests/test_simdd_json_parser.py
+++ b/tango_simlib/tests/test_simdd_json_parser.py
@@ -3,7 +3,7 @@ import unittest
 import logging
 import pkg_resources
 
-import PyTango
+import tango
 from tango.test_context import DeviceTestContext
 
 from katcp.testutils import start_thread_with_cleanup
@@ -42,7 +42,7 @@ EXPECTED_TEMPERATURE_ATTR_INFO = {
         'archive_period': '1000',
         'archive_rel_change': '10',
         'data_format': 'Scalar',
-        'data_type': PyTango._PyTango.CmdArgType.DevDouble,
+        'data_type': tango._tango.CmdArgType.DevDouble,
         'format': '6.2f',
         'delta_t': '1000',
         'delta_val': '0.5',
@@ -358,7 +358,7 @@ class test_SimddDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase):
         self.assertEqual(self.device.command_inout(command_name),
                          expected_result)
         self.assertEqual(getattr(self.device.read_attribute('State'), 'value'),
-                         PyTango.DevState.ON)
+                         tango.DevState.ON)
 
     def test_Add_command(self):
         """Testing that the Tango device command can take input of an array type and
@@ -391,7 +391,7 @@ class test_SimddDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase):
         self.assertEqual(self.device.command_inout(command_name),
                          expected_result)
         self.assertEqual(getattr(self.device.read_attribute('State'), 'value'),
-                         PyTango.DevState.OFF)
+                         tango.DevState.OFF)
 
     def test_set_temperature_command(self):
         """Testing that the SetTemperature command changes the temperature

--- a/tango_simlib/tests/test_simdd_json_parser.py
+++ b/tango_simlib/tests/test_simdd_json_parser.py
@@ -1,18 +1,18 @@
 import mock
 import unittest
 import logging
-
-import PyTango
 import pkg_resources
 
-from devicetest import TangoTestContext
+import PyTango
+from tango.test_context import DeviceTestContext
 
-from tango_simlib.testutils import cleanup_tempfile
 from katcp.testutils import start_thread_with_cleanup
+
 from tango_simlib import simdd_json_parser, helper_module
 from tango_simlib import sim_xmi_parser, model
 from tango_simlib import tango_sim_generator
 from tango_simlib.examples import override_class
+from tango_simlib.testutils import cleanup_tempfile
 from tango_simlib.testutils import ClassCleanupUnittestMixin
 
 
@@ -269,9 +269,9 @@ class test_SimddDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase):
                                                            cls.device_name)
         cls.TangoDeviceServer = tango_sim_generator.get_tango_device_server(
                     model, cls.data_descr_file)[0]
-        cls.tango_context = TangoTestContext(cls.TangoDeviceServer,
-                                             device_name=cls.device_name,
-                                             db=cls.tango_db)
+        cls.tango_context = DeviceTestContext(cls.TangoDeviceServer,
+                                              device_name=cls.device_name,
+                                              db=cls.tango_db)
         start_thread_with_cleanup(cls, cls.tango_context)
 
     def setUp(self):
@@ -435,9 +435,9 @@ class test_XmiSimddDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCas
             cls.data_descr_files, cls.device_name)
         cls.TangoDeviceServer = tango_sim_generator.get_tango_device_server(
             model, cls.data_descr_files)[0]
-        cls.tango_context = TangoTestContext(cls.TangoDeviceServer,
-                                             device_name=cls.device_name,
-                                             db=cls.tango_db)
+        cls.tango_context = DeviceTestContext(cls.TangoDeviceServer,
+                                              device_name=cls.device_name,
+                                              db=cls.tango_db)
         start_thread_with_cleanup(cls, cls.tango_context)
 
     def setUp(self):
@@ -596,9 +596,9 @@ class test_XmiSimddSupplementaryDeviceIntegration(ClassCleanupUnittestMixin,
             cls.data_descr_files, cls.device_name)
         cls.TangoDeviceServer = tango_sim_generator.get_tango_device_server(
             model, cls.data_descr_files)[0]
-        cls.tango_context = TangoTestContext(cls.TangoDeviceServer,
-                                             device_name=cls.device_name,
-                                             db=cls.tango_db)
+        cls.tango_context = DeviceTestContext(cls.TangoDeviceServer,
+                                              device_name=cls.device_name,
+                                              db=cls.tango_db)
         start_thread_with_cleanup(cls, cls.tango_context)
 
     def setUp(self):

--- a/tango_simlib/tests/test_tango_sim_generator.py
+++ b/tango_simlib/tests/test_tango_sim_generator.py
@@ -6,7 +6,6 @@ import tempfile
 import subprocess
 import pkg_resources
 
-#import devicetest
 import PyTango
 
 from tango_simlib.testutils import ClassCleanupUnittestMixin
@@ -35,8 +34,6 @@ class test_TangoSimGenDeviceIntegration(ClassCleanupUnittestMixin, unittest.Test
         sim_test_device_prop = dict(model_key=device_name)
         dp = PyTango.DeviceProxy('%s:%s/test/nodb/tangodeviceserver#dbase=no' % (
                     cls.host, cls.port))
-        #patcher = devicetest.patch.Patcher()
-       # device_proxy = patcher.ActualDeviceProxy
         tango_sim_generator.generate_device_server(
                 server_name, cls.data_descr_file, cls.temp_dir)
         helper_module.append_device_to_db_file(

--- a/tango_simlib/tests/test_tango_sim_generator.py
+++ b/tango_simlib/tests/test_tango_sim_generator.py
@@ -4,13 +4,13 @@ import unittest
 import shutil
 import tempfile
 import subprocess
-
 import pkg_resources
-import devicetest
+
+#import devicetest
+import PyTango
 
 from tango_simlib.testutils import ClassCleanupUnittestMixin
 from tango_simlib import tango_sim_generator, sim_xmi_parser, helper_module
-
 from tango_simlib.tests import test_sim_test_interface
 
 MODULE_LOGGER = logging.getLogger(__name__)
@@ -33,8 +33,10 @@ class test_TangoSimGenDeviceIntegration(ClassCleanupUnittestMixin, unittest.Test
         server_instance = 'test'
         database_filename = '%s/%s_tango.db' % (cls.temp_dir, server_name)
         sim_test_device_prop = dict(model_key=device_name)
-        patcher = devicetest.patch.Patcher()
-        device_proxy = patcher.ActualDeviceProxy
+        dp = PyTango.DeviceProxy('%s:%s/test/nodb/tangodeviceserver#dbase=no' % (
+                    cls.host, cls.port))
+        #patcher = devicetest.patch.Patcher()
+       # device_proxy = patcher.ActualDeviceProxy
         tango_sim_generator.generate_device_server(
                 server_name, cls.data_descr_file, cls.temp_dir)
         helper_module.append_device_to_db_file(
@@ -53,10 +55,10 @@ class test_TangoSimGenDeviceIntegration(ClassCleanupUnittestMixin, unittest.Test
         # Note that tango demands that connection to the server must
         # be delayed by atleast 1000 ms of device server start up.
         time.sleep(1)
-        cls.sim_device = device_proxy(
+        cls.sim_device = PyTango.DeviceProxy(
                 '%s:%s/test/nodb/tangodeviceserver#dbase=no' % (
                     cls.host, cls.port))
-        cls.sim_control_device = device_proxy(
+        cls.sim_control_device = PyTango.DeviceProxy(
                 '%s:%s/test/nodb/tangodeviceservercontrol#dbase=no' % (
                     cls.host, cls.port))
         cls.addCleanupClass(cls.sub_proc.kill)

--- a/tango_simlib/tests/test_tango_sim_generator.py
+++ b/tango_simlib/tests/test_tango_sim_generator.py
@@ -43,12 +43,10 @@ class test_TangoSimGenDeviceIntegration(ClassCleanupUnittestMixin, unittest.Test
                             server_name, server_instance, '%scontrol' % device_name,
                             database_filename, '%sSimControl' % cls.sim_device_class,
                             sim_test_device_prop)
-        cls.sub_proc = subprocess.Popen(["python", "{}/{}".format(
-                                            cls.temp_dir, server_name),
-                                        server_instance, "-file={}".format(
-                                            database_filename),
-                                        "-ORBendPoint", "giop:tcp::{}".format(
-                                            cls.port)])
+        cls.sub_proc = subprocess.Popen(
+            ["python", "{}/{}".format(cls.temp_dir, server_name),
+             server_instance, "-file={}".format(database_filename),
+             "-ORBendPoint", "giop:tcp::{}".format( cls.port)])
         # Note that tango demands that connection to the server must
         # be delayed by atleast 1000 ms of device server start up.
         time.sleep(1)

--- a/tango_simlib/tests/test_tango_sim_generator.py
+++ b/tango_simlib/tests/test_tango_sim_generator.py
@@ -6,10 +6,10 @@ import tempfile
 import subprocess
 import pkg_resources
 
-import PyTango
+import tango
 
-from tango_simlib.testutils import ClassCleanupUnittestMixin
 from tango_simlib import tango_sim_generator, sim_xmi_parser, helper_module
+from tango_simlib.testutils import ClassCleanupUnittestMixin
 from tango_simlib.tests import test_sim_test_interface
 
 MODULE_LOGGER = logging.getLogger(__name__)
@@ -32,8 +32,6 @@ class test_TangoSimGenDeviceIntegration(ClassCleanupUnittestMixin, unittest.Test
         server_instance = 'test'
         database_filename = '%s/%s_tango.db' % (cls.temp_dir, server_name)
         sim_test_device_prop = dict(model_key=device_name)
-        dp = PyTango.DeviceProxy('%s:%s/test/nodb/tangodeviceserver#dbase=no' % (
-                    cls.host, cls.port))
         tango_sim_generator.generate_device_server(
                 server_name, cls.data_descr_file, cls.temp_dir)
         helper_module.append_device_to_db_file(
@@ -50,10 +48,10 @@ class test_TangoSimGenDeviceIntegration(ClassCleanupUnittestMixin, unittest.Test
         # Note that tango demands that connection to the server must
         # be delayed by atleast 1000 ms of device server start up.
         time.sleep(1)
-        cls.sim_device = PyTango.DeviceProxy(
+        cls.sim_device = tango.DeviceProxy(
                 '%s:%s/test/nodb/tangodeviceserver#dbase=no' % (
                     cls.host, cls.port))
-        cls.sim_control_device = PyTango.DeviceProxy(
+        cls.sim_control_device = tango.DeviceProxy(
                 '%s:%s/test/nodb/tangodeviceservercontrol#dbase=no' % (
                     cls.host, cls.port))
         cls.addCleanupClass(cls.sub_proc.kill)


### PR DESCRIPTION
The [devicetest](https://github.com/vxgmichel/pytango-devicetest) library is no longer being maintained since the testing features were added to the the [pytango repository](https://github.com/tango-controls/pytango/blob/develop/tango/test_context.py). Going forward the pytango unit-testing features will be used for testing the PyTango devices.

JIRA: CB-2672