### PR TITLE
adding max_dim_x and max_dim_y for SCALAR format attributes as well

### DIFF
--- a/tango_simlib/tests/test_fandango_json_parser.py
+++ b/tango_simlib/tests/test_fandango_json_parser.py
@@ -67,6 +67,8 @@ EXPECTED_STATUS_ATTR_INFO = {
     'format': '%s',
     'label': 'Status',
     'max_alarm': 'Not specified',
+    'max_dim_x': 1,
+    'max_dim_y': 0,
     'min_alarm': 'Not specified',
     'model': 'monctl:10000/sys/database/2/Status',
     'name': 'Status',

--- a/tango_simlib/utilities/fandango_json_parser.py
+++ b/tango_simlib/utilities/fandango_json_parser.py
@@ -87,6 +87,10 @@ class FandangoExportDeviceParser(Parser):
                     if (attr_prop_value == 'SPECTRUM' and 
                         'max_dim_x' not in attr_config.keys()):
                         max_dim[attr]= {'max_dim_x': len(attr_config['value']), 'max_dim_y': 0}
+                    # checking if SCALAR format attr has max_dim_x key not registered
+                    elif (attr_prop_value == 'SCALAR' and
+                        'max_dim_x' not in attr_config.keys()):
+                        max_dim[attr]= {'max_dim_x': 1, 'max_dim_y': 0}
                     attr_config[attr_prop] = (
                         getattr(AttrDataFormat, attr_prop_value))
 


### PR DESCRIPTION
The fandango parser has been updated to add the `max_dim_x` and `max_dim_y` keys to `SCALAR` format attributes as well so that the launcher runs without errors.
This is PR is an extension of the task described in

JIRA ticket: [CB-2866](https://skaafrica.atlassian.net/browse/CB-2866). 