### PR TITLE
Updating key values of device properties to dict

### DIFF
--- a/tango_simlib/utilities/fandango_json_parser.py
+++ b/tango_simlib/utilities/fandango_json_parser.py
@@ -125,7 +125,7 @@ class FandangoExportDeviceParser(Parser):
                 '<property-name>': {
                     'DefaultPropValue': '<list-of-strings>',
                     'name': '<property-name>',
-                    'type': '<data-type>'},
+                    'type': '<data-type>'}
             }
 
         """
@@ -238,11 +238,7 @@ class FandangoExportDeviceParser(Parser):
                 '<property-name>': {
                     'DefaultPropValue': '<list-of-strings>',
                     'name': '<property-name>',
-                    'type': '<data-type>'},
-                '<property-name>': {
-                    'DefaultPropValue': '<list-of-strings>',
-                    'name': '<property-name>',
-                    'type': '<data-type>'},
+                    'type': '<data-type>'}
             }
         """
         return self._device_properties

--- a/tango_simlib/utilities/fandango_json_parser.py
+++ b/tango_simlib/utilities/fandango_json_parser.py
@@ -235,7 +235,14 @@ class FandangoExportDeviceParser(Parser):
             info in a dict.
             e.g.
             {
-                '<property_name>': <property_value>,
+                '<property-name>': {
+                    'DefaultPropValue': '<list-of-strings>',
+                    'name': '<property-name>',
+                    'type': '<data-type>'},
+                '<property-name>': {
+                    'DefaultPropValue': '<list-of-strings>',
+                    'name': '<property-name>',
+                    'type': '<data-type>'},
             }
         """
         return self._device_properties

--- a/tango_simlib/utilities/fandango_json_parser.py
+++ b/tango_simlib/utilities/fandango_json_parser.py
@@ -1,4 +1,4 @@
-######################################################################################### 
+#########################################################################################
 # Author: cam@ska.ac.za                                                                 #
 # Copyright 2018 SKA South Africa (http://ska.ac.za/)                                   #
 #                                                                                       #
@@ -32,7 +32,7 @@ CMD_PROP_MAP = {
 class FandangoExportDeviceParser(Parser):
 
     def __init__(self):
-	super(FandangoExportDeviceParser, self).__init__() 
+        super(FandangoExportDeviceParser, self).__init__()
 
         self._device_class_properties = {}
 
@@ -51,8 +51,8 @@ class FandangoExportDeviceParser(Parser):
             elif data_component == 'properties':
                 self.update_property_data(elements)
             elif data_component == 'dev_class':
-                self.device_class_name = elements     
-
+                self.device_class_name = elements
+    
     def preprocess_command_types(self, command_data):
         """Convert the command input and output data types from strings to the TANGO
         types and rename the command properties to match with the keyword arguments of
@@ -87,9 +87,11 @@ class FandangoExportDeviceParser(Parser):
                         attr_config['writable'] = 'READ_WRITE'
                 elif attr_prop == 'data_format':
                     # checking if SPECTRUM format attr has max_dim_x key not registered
-                    if (attr_prop_value == 'SPECTRUM' and 
+                    if (attr_prop_value == 'SPECTRUM' and
                         'max_dim_x' not in attr_config.keys()):
-                        max_dim[attr] = {'max_dim_x': len(attr_config['value']), 'max_dim_y': 0}
+                        max_dim[attr] = {
+                            'max_dim_x': len(attr_config['value']),'max_dim_y': 0
+                            }
                     # checking if SCALAR format attr has max_dim_x key not registered
                     elif (attr_prop_value == 'SCALAR' and
                         'max_dim_x' not in attr_config.keys()):
@@ -105,8 +107,21 @@ class FandangoExportDeviceParser(Parser):
     def update_property_data(self, property_data):
         """Update key values to a dict with keys 'DefaultPropValue','name' and 'type'
 
+        Parameters
+        ----------
+        property_data: dict
         e.g.
             {
+                '<property-name>': '<list-of-strings>',
+                '<property-name>': '<list-of-strings>'
+            }
+
+        property_data is reformatted to the format below
+            {
+                '<property-name>': {
+                    'DefaultPropValue': '<list-of-strings>',
+                    'name': '<property-name>',
+                    'type': '<data-type>'},
                 '<property-name>': {
                     'DefaultPropValue': '<list-of-strings>',
                     'name': '<property-name>',
@@ -114,19 +129,21 @@ class FandangoExportDeviceParser(Parser):
             }
 
         """
-        prop_data = {}
-        for prop, prop_val in property_data.items():
-            prop_data[prop] = {
-                'DefaultPropValue': prop_val,
-                'name': prop,
-                'type': 'VarStringArray'
-                }
+        prop_data = [
+            (
+                prop,
+                dict([
+                        ('DefaultPropValue', prop_val),
+                        ('name', prop),
+                        ('type', 'VarStringArray')
+                        ])
+                ) for prop, prop_val in property_data.items()
+            ]
 
-        for prop, config in prop_data.items():
-            property_data[prop] = config
+        property_data = dict(prop_data)
 
-        self._device_properties.update(property_data)           
-
+        self._device_properties.update(property_data)
+        
     def get_device_attribute_metadata(self):
         """Returns the device's attributes' configuration.
 


### PR DESCRIPTION
The fandango parser assigns a dict to the key values for the different properties in the form
 {
'property-name': {
    'DefaultPropValue': 'list-of-strings',
    'name': 'property-name',
     'type': 'data-type'},
 }
This will eliminate the current errors encountered when the launcher is run. Then the task in ticket number below can be addressed.

JIRA ticket: [CB-2917](https://skaafrica.atlassian.net/browse/CB-2917)