### PR TITLE
User/stwum/cb 2918/fixing new errors in tango simlib

### DIFF
--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -1,5 +1,3 @@
-#!/usr/bin/env python
-######################################################################################### 
 # Copyright 2017 SKA South Africa (http://ska.ac.za/)                                   #
 #                                                                                       #
 # BSD license - see LICENSE.txt for details                                             #
@@ -463,9 +461,9 @@ def get_device_class(sim_data_files):
     for data_file in sim_data_files:
         extension = os.path.splitext(data_file)[-1]
         extension = extension.lower()
-        if extension in [".xmi"]:
+        if extension in [".xmi", ".fgo"]:
             parser_instance = get_parser_instance(data_file)
-        elif extension in [".fgo", ".json"] and len(sim_data_files) < 2:
+        elif extension in [".json"] and len(sim_data_files) < 2:
             parser_instance = get_parser_instance(data_file)
 
     # Since at the current moment the class name of the tango simulator to be

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -1,3 +1,5 @@
+#!/usr/bin/env python
+######################################################################################### 
 # Copyright 2017 SKA South Africa (http://ska.ac.za/)                                   #
 #                                                                                       #
 # BSD license - see LICENSE.txt for details                                             #

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -458,13 +458,15 @@ def get_device_class(sim_data_files):
 
     parser_instance = None
     klass_name = ''
-    for data_file in sim_data_files:
-        extension = os.path.splitext(data_file)[-1]
+    precedence_map = {'.xmi': 1, '.fgo': 2, '.json': 3}
+
+    def get_precedence(file_name):
+        extension = os.path.splitext(file_name)[-1]
         extension = extension.lower()
-        if extension in [".xmi", ".fgo"]:
-            parser_instance = get_parser_instance(data_file)
-        elif extension in [".json"] and len(sim_data_files) < 2:
-            parser_instance = get_parser_instance(data_file)
+        return precedence_map.get(extension, 100)
+
+    sorted_files = sorted(sim_data_files, key=get_precedence)
+    parser_instance = get_parser_instance(sorted_files[0])
 
     # Since at the current moment the class name of the tango simulator to be
     # generated must be specified in the xmi data file, if no xmi if provided

--- a/tango_simlib/utilities/fandango_json_parser.py
+++ b/tango_simlib/utilities/fandango_json_parser.py
@@ -77,8 +77,8 @@ class FandangoExportDeviceParser(Parser):
     def preprocess_attribute_types(self, attribute_data):
         """Convert the attribute data types from strings to the TANGO types.
         """
-        max_dim = {}
         for attr, attr_config in attribute_data.items():
+            
             # assign 'READ_WRITE' to all attributes with 'WT_UNKNOWN'
             if attr_config['writable'] not in ['READ', 'WRITE', 'READ_WRITE']:
                 attr_config['writable'] = 'READ_WRITE'
@@ -86,21 +86,8 @@ class FandangoExportDeviceParser(Parser):
                 if attr_prop == 'data_type':
                     attr_config[attr_prop] = getattr(CmdArgType, attr_prop_value)
                 elif attr_prop == 'data_format':
-                    # checking if SPECTRUM format attr has max_dim_x key not registered
-                    if (attr_prop_value == 'SPECTRUM' and
-                        'max_dim_x' not in attr_config.keys()):
-                        max_dim[attr] = {
-                            'max_dim_x': len(attr_config['value']),'max_dim_y': 0
-                            }
-                    # checking if SCALAR format attr has max_dim_x key not registered
-                    elif (attr_prop_value == 'SCALAR' and
-                        'max_dim_x' not in attr_config.keys()):
-                        max_dim[attr] = {'max_dim_x': 1, 'max_dim_y': 0}
                     attr_config[attr_prop] = (
                         getattr(AttrDataFormat, attr_prop_value))
-
-        for attr, max_config in max_dim.items():
-            attribute_data[attr].update(max_config)
 
         self._device_attributes.update(attribute_data)
 

--- a/tango_simlib/utilities/fandango_json_parser.py
+++ b/tango_simlib/utilities/fandango_json_parser.py
@@ -79,12 +79,12 @@ class FandangoExportDeviceParser(Parser):
         """
         max_dim = {}
         for attr, attr_config in attribute_data.items():
+            # assign 'READ_WRITE' to all attributes with 'WT_UNKNOWN'
+            if attr_config['writable'] not in ['READ', 'WRITE', 'READ_WRITE']:
+                attr_config['writable'] = 'READ_WRITE'
             for attr_prop, attr_prop_value in attr_config.items():
                 if attr_prop == 'data_type':
                     attr_config[attr_prop] = getattr(CmdArgType, attr_prop_value)
-                    # ensuring READ_WRITE is assigned to 'writable' key for all DevEnum
-                    if attr_prop_value == "DevEnum":
-                        attr_config['writable'] = 'READ_WRITE'
                 elif attr_prop == 'data_format':
                     # checking if SPECTRUM format attr has max_dim_x key not registered
                     if (attr_prop_value == 'SPECTRUM' and


### PR DESCRIPTION
This is a fix for two errors encountered:

- The default tango device server is chosen when the json file is added to the sim_data_files in the [DishManager](https://github.com/ska-sa/katsim/blob/master/scripts/DishManager) script. Fix is in tango-sim generator.

- Apparently there were still some attributes that have 'WT_UNKNOWN' registered as the value for the attribute property 'writable' which produces the error in the image below. The fix in the fandango parser is to change all attributes whose 'writable' value is 'WT_UNKNOWN' to 'READ_WRITE'.

These are not the tasks specified in the JIRA ticket CB-2918 but the these errors were encountered working on this issue.

JIRA ticket: CB-[2918](https://skaafrica.atlassian.net/browse/CB-2918)