### PR TITLE
including file option in launcher script

### DIFF
--- a/tango_simlib/tango_launcher.py
+++ b/tango_simlib/tango_launcher.py
@@ -40,17 +40,16 @@ parser.add_argument('--put-device-property', action='append', help=
                     "Can be specified multiple times.",
                     dest='device_properties', default=[])
 
-def register_device(name, device_class, server_name, instance, file_name=None):
-    if not file_name:
-        dev_info = tango.DbDevInfo()
-        dev_info.name = name
-        dev_info._class = device_class
-        dev_info.server = "{}/{}".format(server_name, instance)
-        print """Attempting to register TANGO device {!r}
-        class: {!r}  server: {!r}.""".format(
-            dev_info.name, dev_info._class, dev_info.server)
-        db = tango.Database()
-        db.add_device(dev_info)
+def register_device(name, device_class, server_name, instance):
+    dev_info = tango.DbDevInfo()
+    dev_info.name = name
+    dev_info._class = device_class
+    dev_info.server = "{}/{}".format(server_name, instance)
+    print """Attempting to register TANGO device {!r}
+    class: {!r}  server: {!r}.""".format(
+        dev_info.name, dev_info._class, dev_info.server)
+    db = tango.Database()
+    db.add_device(dev_info)
 
 def put_device_property(dev_name, property_name, property_value, file_name):
     if file_name:
@@ -65,9 +64,10 @@ def start_device(opts):
     server_name = os.path.basename(opts.server_command)
     number_of_devices = len(opts.name)
     # Register tango devices
-    for i in range(number_of_devices):
-        register_device(
-            opts.name[i], opts.device_class[i], server_name, opts.server_instance, opts.file_name)
+    if not opts.file_name:
+        for i in range(number_of_devices):
+            register_device(
+                opts.name[i], opts.device_class[i], server_name, opts.server_instance)
     for dev_property in opts.device_properties:
         try:
             dev_name, dev_property_name, dev_property_val = dev_property.split(

--- a/tango_simlib/tango_launcher.py
+++ b/tango_simlib/tango_launcher.py
@@ -30,6 +30,8 @@ required_argument('--class', dest='device_class', action='append',
                   "same number of times and the names and classes are matched in order")
 required_argument('--server-command', help="TANGO server executable command")
 required_argument('--server-instance', help="TANGO server instance name")
+required_argument('--file', help="ASCII file containing device configuration parameters" +
+                  "and device network access parameter")
 required_argument('--port', help="TCP port where TANGO server should listen")
 parser.add_argument('--put-device-property', action='append', help=
                     "Put a device property into the TANGO DB, format is: "
@@ -58,7 +60,7 @@ def put_device_property(dev_name, property_name, property_value):
 def start_device(opts):
     server_name = os.path.basename(opts.server_command)
     number_of_devices = len(opts.name)
-    #Register tango devices
+    # Register tango devices
     for i in range(number_of_devices):
         register_device(
             opts.name[i], opts.device_class[i], server_name, opts.server_instance)
@@ -83,6 +85,7 @@ def start_device(opts):
     else:
         args = [opts.server_command,
                 opts.server_instance,
+                opts.file,
                '-ORBendPoint', 'giop:tcp::{}'.format(opts.port)]
         print "Starting TANGO device server:\n{}".format(
               " ".join(["{!r}".format(arg) for arg in args]))

--- a/tango_simlib/tango_launcher.py
+++ b/tango_simlib/tango_launcher.py
@@ -44,7 +44,7 @@ def register_device(name, device_class, server_name, instance):
     dev_info = tango.DbDevInfo()
     dev_info.name = name
     dev_info._class = device_class
-    dev_info.server = "{}/{}".format(server_name, instance)
+    dev_info.server = "{}/{}".format(server_name.split('.')[0], instance)
     print """Attempting to register TANGO device {!r}
     class: {!r}  server: {!r}.""".format(
         dev_info.name, dev_info._class, dev_info.server)

--- a/tango_simlib/tango_launcher.py
+++ b/tango_simlib/tango_launcher.py
@@ -63,7 +63,7 @@ def put_device_property(dev_name, property_name, property_value, file_name):
 def start_device(opts):
     server_name = os.path.basename(opts.server_command)
     number_of_devices = len(opts.name)
-    # Register tango devices
+    # Register tango devices if TANGO DB is being used
     if not opts.file_name:
         for i in range(number_of_devices):
             register_device(

--- a/tango_simlib/tango_launcher.py
+++ b/tango_simlib/tango_launcher.py
@@ -53,7 +53,10 @@ def register_device(name, device_class, server_name, instance, file_name=None):
         db.add_device(dev_info)
 
 def put_device_property(dev_name, property_name, property_value, file_name):
-    db = tango.Database(file_name)
+    if file_name:
+        db = tango.Database(file_name)
+    else:
+        db = tango.Database()
     print "Setting device {!r} property {!r}: {!r}".format(
         dev_name, property_name, property_value)
     db.put_device_property(dev_name, {property_name:[property_value]})

--- a/tango_simlib/tango_launcher.py
+++ b/tango_simlib/tango_launcher.py
@@ -76,7 +76,7 @@ def start_device(opts):
         put_device_property(dev_name, dev_property_name, dev_property_val)
 
     if '.py' in opts.server_command:
-        args = ['python %s' % opts.server_command, opts.server_instance]
+        args = ['python %s' % opts.server_command, opts.server_instance, opts.file]
         print "Starting TANGO device server:\n{}".format(
               " ".join(["{!r}".format(arg) for arg in args]))
         sys.stdout.flush()

--- a/tango_simlib/tango_launcher.py
+++ b/tango_simlib/tango_launcher.py
@@ -32,7 +32,7 @@ required_argument('--server-command', help="TANGO server executable command")
 required_argument('--server-instance', help="TANGO server instance name")
 required_argument('--port', help="TCP port where TANGO server should listen")
 parser.add_argument('--file-name', help="ASCII file containing device configuration parameters" +
-                    "and device network access parameter")
+                    "and device network access parameter if TANGO DB server is not used")
 parser.add_argument('--put-device-property', action='append', help=
                     "Put a device property into the TANGO DB, format is: "
                     "'device/name/X:property_name:property_value'. Only allows "


### PR DESCRIPTION
We do not want to depend on a tangodb device server.  The goal is to run the device server using a file as the database. The simplest way to generate this file is to use the Jive application as indicated [here](http://www.esrf.eu/computing/cs/tango/tango_doc/tools_doc/jive_doc/index.html). The launcher script has been updated to include the file as an optional argument.

JIRA ticket: [CB-2917](https://skaafrica.atlassian.net/browse/CB-2959)