### PR TITLE
updating the model and generator scripts to ensure the accurate overr…

### DIFF
--- a/tango_simlib/model.py
+++ b/tango_simlib/model.py
@@ -257,7 +257,7 @@ class PopulateModelQuantities(object):
                         raise ValueError(
                             "Attribute with name '{}' specified in the configuration"
                             " file [{}] has no mininum or maximum values set".format(
-                                attr_name, 
+                                attr_name,
                                 self.parser_instance.data_description_file_name))
                     quantity_factory = (
                             quantities.registry[attr_props['quantity_simulation_type']])

--- a/tango_simlib/model.py
+++ b/tango_simlib/model.py
@@ -218,8 +218,8 @@ class PopulateModelQuantities(object):
                 # props template are removed.
                 # i.e. All optional parameters not provided in the SIMDD
                 attr_props = dict((param_key, param_val)
-                                for param_key, param_val in attr_props.iteritems()
-                                if param_val)
+                                  for param_key, param_val in attr_props.iteritems()
+                                  if param_val)
                 model_attr_props = dict(model_attr_props.items() + attr_props.items())
 
             if model_attr_props.has_key('quantity_simulation_type'):
@@ -351,14 +351,14 @@ class PopulateModelActions(object):
                 pre_update_overwrite = getattr(inst, 'pre_update')
             except AttributeError:
                 MODULE_LOGGER.info("No pre-update method defined in the '{}'"
-                                " override class.".format(type(inst).__name__))
+                                   " override class.".format(type(inst).__name__))
             else:
                 self.sim_model.override_pre_updates.append(pre_update_overwrite)
             try:
                 post_update_overwrite = getattr(inst, 'post_update')
             except AttributeError:
                 MODULE_LOGGER.info("No post-update method defined in the '{}'"
-                                " override class.".format(type(inst).__name__))
+                                   " override class.".format(type(inst).__name__))
             else:
                 self.sim_model.override_post_updates.append(post_update_overwrite)
 
@@ -384,11 +384,11 @@ class PopulateModelActions(object):
                     if instance_.startswith('SimControl'):
                         instance = instances[instance_]
                 self._check_override_action_presence(cmd_name, instance,
-                                                    'test_action_{}')
+                                                     'test_action_{}')
                 handler = getattr(
                     instance, 'test_action_{}'.format(cmd_name.lower()),
                     self.generate_action_handler(cmd_name, cmd_meta['dtype_out'],
-                                                actions))
+                                                 actions))
                 self.sim_model.set_test_sim_action(cmd_name, handler)
             else:
                 for instance_ in instances:
@@ -396,8 +396,8 @@ class PopulateModelActions(object):
                         instance = instances[instance_]
                 self._check_override_action_presence(cmd_name, instance, 'action_{}')
                 handler = getattr(instance, 'action_{}'.format(cmd_name.lower()),
-                                self.generate_action_handler(
-                                    cmd_name, cmd_meta['dtype_out'], actions))
+                                  self.generate_action_handler(
+                                       cmd_name, cmd_meta['dtype_out'], actions))
 
                 self.sim_model.set_sim_action(cmd_name, handler)
             # Might store the action's metadata in the sim_actions dictionary

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -407,10 +407,6 @@ def configure_device_model(sim_data_file=None, test_device_name=None):
     # In case there is more than one parser instance for each file
     model = Model(dev_name)
     for parser in parsers:
-        # model_quantity_populator = PopulateModelQuantities(parser, dev_name, model)
-        # sim_model = model_quantity_populator.sim_model
-        # PopulateModelActions(parser, dev_name, sim_model)
-        # PopulateModelProperties(parser, dev_name, sim_model)
         PopulateModelQuantities(parser, dev_name, model)
         PopulateModelProperties(parser, dev_name, model)
     PopulateModelActions(parsers, dev_name, model)

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -406,18 +406,14 @@ def configure_device_model(sim_data_file=None, test_device_name=None):
 
     # In case there is more than one parser instance for each file
     model = Model(dev_name)
-    attribute_info = {}
-    command_info = {}
-    properties_info = {}
-    override_info = {}
     for parser in parsers:
-        attribute_info.update(parser.get_device_attribute_metadata())
-        command_info.update(parser.get_device_command_metadata())
-        properties_info.update(parser.get_device_properties_metadata('deviceProperties'))
-        override_info.update(parser.get_device_cmd_override_metadata())
-    PopulateModelQuantities(attribute_info, dev_name, model)
-    PopulateModelActions(command_info, override_info, dev_name, model)
-    PopulateModelProperties(properties_info, dev_name, model)
+        # model_quantity_populator = PopulateModelQuantities(parser, dev_name, model)
+        # sim_model = model_quantity_populator.sim_model
+        # PopulateModelActions(parser, dev_name, sim_model)
+        # PopulateModelProperties(parser, dev_name, sim_model)
+        PopulateModelQuantities(parser, dev_name, model)
+        PopulateModelProperties(parser, dev_name, model)
+    PopulateModelActions(parsers, dev_name, model)
     return model
 
 def generate_device_server(server_name, sim_data_files, directory=''):
@@ -506,3 +502,4 @@ def main():
 
 if __name__ == "__main__":
     main()
+    

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -406,10 +406,17 @@ def configure_device_model(sim_data_file=None, test_device_name=None):
 
     # In case there is more than one parser instance for each file
     model = Model(dev_name)
+    command_info = {}
+    properties_info = {}
+    override_info = {}
     for parser in parsers:
         PopulateModelQuantities(parser, dev_name, model)
-        PopulateModelProperties(parser, dev_name, model)
-    PopulateModelActions(parsers, dev_name, model)
+        command_info.update(parser.get_device_command_metadata())
+        properties_info.update(parser.get_device_properties_metadata('deviceProperties'))
+        override_info.update(parser.get_device_cmd_override_metadata())
+    PopulateModelActions(command_info, override_info, dev_name, model)
+    PopulateModelProperties(properties_info, dev_name, model)
+    
     return model
 
 def generate_device_server(server_name, sim_data_files, directory=''):
@@ -498,4 +505,3 @@ def main():
 
 if __name__ == "__main__":
     main()
-    

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -401,16 +401,23 @@ def configure_device_model(sim_data_file=None, test_device_name=None):
     # In case there are more than one data description files to be used to configure the
     # device.
     parsers = []
-    for file_descriptor in data_file:
-        parsers.append(get_parser_instance(file_descriptor))
+    for file_name in data_file:
+        parsers.append(get_parser_instance(file_name))
 
     # In case there is more than one parser instance for each file
     model = Model(dev_name)
+    attribute_info = {}
+    command_info = {}
+    properties_info = {}
+    override_info = {}
     for parser in parsers:
-        model_quantity_populator = PopulateModelQuantities(parser, dev_name, model)
-        sim_model = model_quantity_populator.sim_model
-        PopulateModelActions(parser, dev_name, sim_model)
-        PopulateModelProperties(parser, dev_name, sim_model)
+        attribute_info.update(parser.get_device_attribute_metadata())
+        command_info.update(parser.get_device_command_metadata())
+        properties_info.update(parser.get_device_properties_metadata('deviceProperties'))
+        override_info.update(parser.get_device_cmd_override_metadata())
+    PopulateModelQuantities(attribute_info, dev_name, model)
+    PopulateModelActions(command_info, override_info, dev_name, model)
+    PopulateModelProperties(properties_info, dev_name, model)
     return model
 
 def generate_device_server(server_name, sim_data_files, directory=''):

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -538,8 +538,9 @@ class test_PopModelActions(GenericSetup):
         """
         device_name = 'tango/device/instance'
         cmd_info = self.xmi_parser.get_device_command_metadata()
+        override_info = self.xmi_parser.get_device_command_metadata()
 
-        sim_model = (model.PopulateModelActions([self.xmi_parser], device_name).sim_model)
+        sim_model = (model.PopulateModelActions(cmd_info, override_info, device_name).sim_model)
         self.assertEqual(len(sim_model.sim_quantities), 0,
                          "The model has some unexpected quantities")
 

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -539,7 +539,7 @@ class test_PopModelActions(GenericSetup):
         device_name = 'tango/device/instance'
         cmd_info = self.xmi_parser.get_device_command_metadata()
 
-        sim_model = (model.PopulateModelActions(self.xmi_parser, device_name).sim_model)
+        sim_model = (model.PopulateModelActions([self.xmi_parser], device_name).sim_model)
         self.assertEqual(len(sim_model.sim_quantities), 0,
                          "The model has some unexpected quantities")
 

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -538,7 +538,7 @@ class test_PopModelActions(GenericSetup):
         """
         device_name = 'tango/device/instance'
         cmd_info = self.xmi_parser.get_device_command_metadata()
-        override_info = self.xmi_parser.get_device_command_metadata()
+        override_info = self.xmi_parser.get_device_cmd_override_metadata()
 
         sim_model = (model.PopulateModelActions(cmd_info, override_info, device_name).sim_model)
         self.assertEqual(len(sim_model.sim_quantities), 0,

--- a/tango_simlib/tests/test_simdd_json_parser.py
+++ b/tango_simlib/tests/test_simdd_json_parser.py
@@ -211,7 +211,9 @@ class test_PopulateModelActions(GenericSetup):
         device_name = 'tango/device/instance'
         pmq = model.PopulateModelQuantities(self.simdd_parser, device_name)
         sim_model = pmq.sim_model
-        model.PopulateModelActions([self.simdd_parser], device_name, sim_model)
+        cmd_info = self.simdd_parser.get_device_command_metadata()
+        override_info = self.simdd_parser.get_device_properties_metadata()
+        model.PopulateModelActions(cmd_info, override_info, device_name, sim_model)
 
         actual_actions_list = sim_model.sim_actions.keys()
         expected_actions_list = ['On', 'Off', 'StopRainfall', 'SetTemperature', 'Add',
@@ -226,7 +228,8 @@ class test_PopulateModelActions(GenericSetup):
         pmq = model.PopulateModelQuantities(self.simdd_parser, device_name)
         sim_model = pmq.sim_model
         cmd_info = self.simdd_parser.get_device_command_metadata()
-        model.PopulateModelActions([self.simdd_parser], device_name, sim_model)
+        override_info = self.simdd_parser.get_device_properties_metadata()
+        model.PopulateModelActions(cmd_info, override_info, device_name, sim_model)
         sim_model_actions_meta = sim_model.sim_actions_meta
 
         for cmd_name, cmd_metadata in cmd_info.items():
@@ -245,7 +248,9 @@ class test_PopulateModelActions(GenericSetup):
         device_name = 'tango/device/instance'
         pmq = model.PopulateModelQuantities(self.simdd_parser, device_name)
         sim_model = pmq.sim_model
-        model.PopulateModelActions([self.simdd_parser], device_name, sim_model)
+        cmd_info = self.simdd_parser.get_device_command_metadata()
+        override_info = self.simdd_parser.get_device_properties_metadata()
+        model.PopulateModelActions(cmd_info, override_info, device_name, sim_model)
         action_on = sim_model.sim_actions['On']
         self.assertEqual(action_on.func.im_class, override_class.OverrideWeather)
 
@@ -253,7 +258,9 @@ class test_PopulateModelActions(GenericSetup):
         device_name = 'tango/device/instance'
         pmq = model.PopulateModelQuantities(self.simdd_parser, device_name)
         sim_model = pmq.sim_model
-        model.PopulateModelActions([self.simdd_parser], device_name, sim_model)
+        cmd_info = self.simdd_parser.get_device_command_metadata()
+        override_info = self.simdd_parser.get_device_properties_metadata()
+        model.PopulateModelActions(cmd_info, override_info, device_name, sim_model)
         action_set_temperature = sim_model.sim_actions['SetTemperature']
         data_in = 25.00
         self.assertEqual(action_set_temperature(data_in), data_in)

--- a/tango_simlib/tests/test_simdd_json_parser.py
+++ b/tango_simlib/tests/test_simdd_json_parser.py
@@ -212,7 +212,7 @@ class test_PopulateModelActions(GenericSetup):
         pmq = model.PopulateModelQuantities(self.simdd_parser, device_name)
         sim_model = pmq.sim_model
         cmd_info = self.simdd_parser.get_device_command_metadata()
-        override_info = self.simdd_parser.get_device_properties_metadata()
+        override_info = self.simdd_parser.get_device_cmd_override_metadata()
         model.PopulateModelActions(cmd_info, override_info, device_name, sim_model)
 
         actual_actions_list = sim_model.sim_actions.keys()
@@ -228,7 +228,7 @@ class test_PopulateModelActions(GenericSetup):
         pmq = model.PopulateModelQuantities(self.simdd_parser, device_name)
         sim_model = pmq.sim_model
         cmd_info = self.simdd_parser.get_device_command_metadata()
-        override_info = self.simdd_parser.get_device_properties_metadata()
+        override_info = self.simdd_parser.get_device_cmd_override_metadata()
         model.PopulateModelActions(cmd_info, override_info, device_name, sim_model)
         sim_model_actions_meta = sim_model.sim_actions_meta
 
@@ -249,7 +249,7 @@ class test_PopulateModelActions(GenericSetup):
         pmq = model.PopulateModelQuantities(self.simdd_parser, device_name)
         sim_model = pmq.sim_model
         cmd_info = self.simdd_parser.get_device_command_metadata()
-        override_info = self.simdd_parser.get_device_properties_metadata()
+        override_info = self.simdd_parser.get_device_cmd_override_metadata()
         model.PopulateModelActions(cmd_info, override_info, device_name, sim_model)
         action_on = sim_model.sim_actions['On']
         self.assertEqual(action_on.func.im_class, override_class.OverrideWeather)
@@ -259,7 +259,7 @@ class test_PopulateModelActions(GenericSetup):
         pmq = model.PopulateModelQuantities(self.simdd_parser, device_name)
         sim_model = pmq.sim_model
         cmd_info = self.simdd_parser.get_device_command_metadata()
-        override_info = self.simdd_parser.get_device_properties_metadata()
+        override_info = self.simdd_parser.get_device_cmd_override_metadata()
         model.PopulateModelActions(cmd_info, override_info, device_name, sim_model)
         action_set_temperature = sim_model.sim_actions['SetTemperature']
         data_in = 25.00

--- a/tango_simlib/tests/test_simdd_json_parser.py
+++ b/tango_simlib/tests/test_simdd_json_parser.py
@@ -211,7 +211,7 @@ class test_PopulateModelActions(GenericSetup):
         device_name = 'tango/device/instance'
         pmq = model.PopulateModelQuantities(self.simdd_parser, device_name)
         sim_model = pmq.sim_model
-        model.PopulateModelActions(self.simdd_parser, device_name, sim_model)
+        model.PopulateModelActions([self.simdd_parser], device_name, sim_model)
 
         actual_actions_list = sim_model.sim_actions.keys()
         expected_actions_list = ['On', 'Off', 'StopRainfall', 'SetTemperature', 'Add',
@@ -226,7 +226,7 @@ class test_PopulateModelActions(GenericSetup):
         pmq = model.PopulateModelQuantities(self.simdd_parser, device_name)
         sim_model = pmq.sim_model
         cmd_info = self.simdd_parser.get_device_command_metadata()
-        model.PopulateModelActions(self.simdd_parser, device_name, sim_model)
+        model.PopulateModelActions([self.simdd_parser], device_name, sim_model)
         sim_model_actions_meta = sim_model.sim_actions_meta
 
         for cmd_name, cmd_metadata in cmd_info.items():
@@ -245,7 +245,7 @@ class test_PopulateModelActions(GenericSetup):
         device_name = 'tango/device/instance'
         pmq = model.PopulateModelQuantities(self.simdd_parser, device_name)
         sim_model = pmq.sim_model
-        model.PopulateModelActions(self.simdd_parser, device_name, sim_model)
+        model.PopulateModelActions([self.simdd_parser], device_name, sim_model)
         action_on = sim_model.sim_actions['On']
         self.assertEqual(action_on.func.im_class, override_class.OverrideWeather)
 
@@ -253,7 +253,7 @@ class test_PopulateModelActions(GenericSetup):
         device_name = 'tango/device/instance'
         pmq = model.PopulateModelQuantities(self.simdd_parser, device_name)
         sim_model = pmq.sim_model
-        model.PopulateModelActions(self.simdd_parser, device_name, sim_model)
+        model.PopulateModelActions([self.simdd_parser], device_name, sim_model)
         action_set_temperature = sim_model.sim_actions['SetTemperature']
         data_in = 25.00
         self.assertEqual(action_set_temperature(data_in), data_in)


### PR DESCRIPTION
The current json and fgo files passed as [sim_data_files](https://github.com/ska-sa/katsim/blob/e8072a4077cf132505c1f6d91a19e9782bbcba33/scripts/DishManager#L10) each hold data for the override class and commands respectively .  The earlier [implementation](https://github.com/ska-sa/tango-simlib/blob/c6de76e171fe23615ae96a8d1d2c0f4fe141dd7c/tango_simlib/tango_sim_generator.py#L409) of creating a model from the generator had an empty command info {} with an instance of the override class passed to the model. As such, the commands sent to the running simulator were not being executed. With this corrected, commands for az & el  movements for the dish simulator can be implemented and tested. 

JIRA ticket: [CB-2958](https://skaafrica.atlassian.net/browse/CB-2958)