### PR TITLE
assigning last_val attribute default values specified in data files

### DIFF
--- a/tango_simlib/model.py
+++ b/tango_simlib/model.py
@@ -11,10 +11,6 @@ import importlib
 
 from functools import partial
 from tango_simlib import quantities
-
-# from tango import (DevBoolean, DevString, DevEnum, DevState,
-#                    DevDouble, DevFloat, DevLong, DevVoid, DevULong)
-
 from tango import CmdArgType
 
 MODULE_LOGGER = logging.getLogger(__name__)
@@ -104,7 +100,6 @@ class Model(object):
     def update(self):
         sim_time = self.time_func()
         dt = sim_time - self.last_update_time
-
         if dt < self.min_update_period or self.paused:
             # Updating the sim_state in case the test interface or external command
             # updated the quantities.
@@ -114,10 +109,10 @@ class Model(object):
                 "Sim {} skipping update at {}, dt {} < {} and pause {}"
                 .format(self.name, sim_time, dt, self.min_update_period, self.paused))
             return
-
+        
         for override_update in self.override_pre_updates:
             override_update(self, sim_time, dt)
-
+            
         MODULE_LOGGER.info("Stepping at {}, dt: {}".format(sim_time, dt))
         self.last_update_time = sim_time
         try:
@@ -304,12 +299,12 @@ class PopulateModelQuantities(object):
                     except KeyError:
                         default_val = model_attr_props['possiblevalues']
                     if attr_data_format == 'SCALAR':
-                            default_val = val_type(default_val)
+                        default_val = val_type(default_val)
                     elif attr_data_format == 'SPECTRUM':
                         default_val = map(val_type, default_val)
                     else:
                         default_val = [[val_type(curr_val) for curr_val in sublist]
-                            for sublist in default_val]
+                                       for sublist in default_val]
                 else:
                     if attr_data_format == 'SCALAR':
                         default_val = val

--- a/tango_simlib/model.py
+++ b/tango_simlib/model.py
@@ -279,7 +279,7 @@ class PopulateModelQuantities(object):
                     attr_data_format = str(model_attr_props['data_format'])
                 except KeyError:
                     attr_data_format = 'SPECTRUM'
-                expected_key_vals = ['max_dim_x', 'max_dim_y']
+                expected_key_vals = ['max_dim_x', 'max_dim_y', 'maxX', 'maxY']
                 # the xmi, json and fgo files have either (max_dim_x, max_dim_y) or
                 # (maxX, maxY) keys. If none of these keys are found in them or in the
                 # xml file, we use default values of 1 for x and 2 for y - same applies
@@ -289,15 +289,13 @@ class PopulateModelQuantities(object):
                         max_dim_x = model_attr_props['max_dim_x']
                         max_dim_y = model_attr_props['max_dim_y']
                     except KeyError:
-                        max_dim_x = model_attr_props['maxX']
-                        max_dim_y = model_attr_props['maxY']
+                        max_dim_x = model_attr_props.get('maxX', 1)
+                        max_dim_y = model_attr_props.get('maxY', 2)
+                    # just in case the keys exist but have no values
                     if not max_dim_x:
                         max_dim_x = 1
                     if not max_dim_y:
                         max_dim_y = 2
-                else:
-                    max_dim_x = 1
-                    max_dim_y = 2
                 
                 val_type, val = INITIAL_CONSTANT_VALUE_TYPES[attr_data_type]
                 expected_key_vals = ['value', 'possiblevalues']

--- a/tango_simlib/model.py
+++ b/tango_simlib/model.py
@@ -271,11 +271,19 @@ class PopulateModelQuantities(object):
             else:
                 key_vals = model_attr_props.keys()
                 attr_data_type = model_attr_props['data_type']
+                # the xmi, json and fgo files have data_format attributes indicating
+                # SPECTRUM, SCALAR OR IMAGE data formats. The xml file does not have this
+                # key in its attribute list. It has a key labelled possiblevalues which
+                # is a list. Hence, SPECTRUM is no data_format is found.
                 try:
                     attr_data_format = str(model_attr_props['data_format'])
                 except KeyError:
                     attr_data_format = 'SPECTRUM'
                 expected_key_vals = ['max_dim_x', 'max_dim_y']
+                # the xmi, json and fgo files have either (max_dim_x, max_dim_y) or
+                # (maxX, maxY) keys. If none of these keys are found in them or in the
+                # xml file, we use default values of 1 for x and 2 for y - same applies
+                # for files where the keys have empty values.
                 if any(key_val in expected_key_vals for key_val in key_vals):
                     try:
                         max_dim_x = model_attr_props['max_dim_x']

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -217,11 +217,19 @@ def get_tango_device_server(model, sim_data_files):
                 sim_quantity_meta_info = simulated_quantity.meta
                 key_vals = sim_quantity_meta_info.keys()
                 attr_data_type = sim_quantity_meta_info['data_type']
+                # the xmi, json and fgo files have data_format attributes indicating
+                # SPECTRUM, SCALAR OR IMAGE data formats. The xml file does not have this
+                # key in its attribute list. It has a key labelled possiblevalues which
+                # is a list. Hence, SPECTRUM is no data_format is found.
                 try:
                     attr_data_format = str(sim_quantity_meta_info['data_format'])
                 except KeyError:
                     attr_data_format = 'SPECTRUM'
                 expected_key_vals = ['max_dim_x', 'max_dim_y']
+                # the xmi, json and fgo files have either (max_dim_x, max_dim_y) or
+                # (maxX, maxY) keys. If none of these keys are found in them or in the
+                # xml file, we use default values of 1 for x and 2 for y - same applies
+                # for files where the keys have empty values.
                 if any(key_val in expected_key_vals for key_val in key_vals):
                     try:
                         max_dim_x = sim_quantity_meta_info['max_dim_x']

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -277,13 +277,12 @@ def get_tango_device_server(model, sim_data_files):
                             adjustable_val = val_type(adjustable_val)
                         simulated_quantity.last_val = adjustable_val
                     else:
-                        sim_attribute_quantities = {
-                            'max_slew_rate': float(sim_quantity_meta_info['min_bound']),
-                            'min_bound': float(sim_quantity_meta_info['max_bound']),
-                            'max_bound': float(sim_quantity_meta_info['max_slew_rate']),
-                            'mean': float(sim_quantity_meta_info['mean']),
-                            'std_dev': float(sim_quantity_meta_info['std_dev'])}
-                        simulated_quantity.last_val = sim_attribute_quantities
+                        simulated_quantity.mean = float(sim_quantity_meta_info['min_bound'])
+                        simulated_quantity.max_bound = float(sim_quantity_meta_info['max_bound'])
+                        simulated_quantity.max_slew_rate = float(sim_quantity_meta_info['max_slew_rate'])
+                        simulated_quantity.mean = float(sim_quantity_meta_info['mean'])
+                        simulated_quantity.std_dev = float(sim_quantity_meta_info['std_dev'])
+                        simulated_quantity.last_val = float(sim_quantity_meta_info['mean'])
 
         def initialize_dynamic_commands(self):
             for action_name, action_handler in self.model.sim_actions.items():

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -225,7 +225,7 @@ def get_tango_device_server(model, sim_data_files):
                     attr_data_format = str(sim_quantity_meta_info['data_format'])
                 except KeyError:
                     attr_data_format = 'SPECTRUM'
-                expected_key_vals = ['max_dim_x', 'max_dim_y']
+                expected_key_vals = ['max_dim_x', 'max_dim_y', 'maxX', 'maxY']
                 # the xmi, json and fgo files have either (max_dim_x, max_dim_y) or
                 # (maxX, maxY) keys. If none of these keys are found in them or in the
                 # xml file, we use default values of 1 for x and 2 for y - same applies
@@ -235,15 +235,13 @@ def get_tango_device_server(model, sim_data_files):
                         max_dim_x = sim_quantity_meta_info['max_dim_x']
                         max_dim_y = sim_quantity_meta_info['max_dim_y']
                     except KeyError:
-                        max_dim_x = sim_quantity_meta_info['maxX']
-                        max_dim_y = sim_quantity_meta_info['maxY']
+                        max_dim_x = sim_quantity_meta_info.get('maxX', 1)
+                        max_dim_y = sim_quantity_meta_info.get('maxY', 2)
+                    # just in case the keys exist but have no values
                     if not max_dim_x:
                         max_dim_x = 1
                     if not max_dim_y:
                         max_dim_y = 2
-                else:
-                    max_dim_x = 1
-                    max_dim_y = 2
 
                 val_type, val = INITIAL_CONSTANT_VALUE_TYPES[attr_data_type]
                 expected_key_vals = ['value', 'possiblevalues']

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -243,6 +243,7 @@ def get_tango_device_server(model, sim_data_files):
                 for attr in adjustable_attrs:
                     if attr == 'last_update_time':
                         simulated_quantity.attr = model_time
+                        continue
                     else:
                         try:
                             sim_quantity_meta_info['quantity_simulation_type']
@@ -273,7 +274,8 @@ def get_tango_device_server(model, sim_data_files):
                             if (sim_quantity_meta_info['quantity_simulation_type'] ==
                                 'ConstantQuantity'):
                                 try:
-                                    initial_value = sim_quantity_meta_info['initial_value']
+                                    initial_value = sim_quantity_meta_info[
+                                                        'initial_value']
                                 except KeyError:
                                     initial_value = None
                                 adjustable_val = (initial_value if initial_value not in
@@ -283,9 +285,11 @@ def get_tango_device_server(model, sim_data_files):
                                 else:
                                     adjustable_val = val_type(adjustable_val)
                             else:
-                                adjustable_val = float(sim_quantity_meta_info[attr])
-                                if attr == 'mean':
-                                    simulated_quantity.last_val = adjustable_val
+                                if attr == 'last_val':
+                                    simulated_quantity.attr = float(sim_quantity_meta_info['mean'])
+                                    continue
+                                else:
+                                    adjustable_val = float(sim_quantity_meta_info[attr])
 
                         simulated_quantity.attr = adjustable_val
                 

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -211,17 +211,33 @@ def get_tango_device_server(model, sim_data_files):
             """Reset the model's quantities' adjustable attributes to their default
             values.
             """
+            type_map = {
+                'DevString': "",
+                'DevFloat': 0.0,
+                'DevDouble': 0.0,
+                'DevBoolean': False,
+                'DevEnum': 0,
+                'DevLong': 0,
+                'DevULong': 0,
+                'DevVoid': None}
             simulated_quantities = self.model.sim_quantities.values()
             for simulated_quantity in simulated_quantities:
                 sim_quantity_meta_info = simulated_quantity.meta
-                adjustable_attrs = simulated_quantity.adjustable_attributes
-
-                for attr in adjustable_attrs:
+                if 'initial_value' in sim_quantity_meta_info.keys():
+                    pass
+                else:
                     try:
-                        adjustable_val = float(sim_quantity_meta_info[attr])
+                        adjustable_val = sim_quantity_meta_info['value']
                     except KeyError:
-                        adjustable_val = 0.0
-                    setattr(simulated_quantity, attr, adjustable_val)
+                        meta_type = str(sim_quantity_meta_info['data_type'])
+                        meta_format = str(sim_quantity_meta_info['data_format'])
+                        if meta_format == 'SCALAR':
+                            adjustable_val = type_map[meta_type]
+                        elif meta_format == 'SPECTRUM':
+                            adjustable_val = [type_map[meta_type]]
+                        else:
+                            adjustable_val = [[type_map[meta_type]]] * 2
+                    setattr(simulated_quantity, 'last_val', adjustable_val)
 
         def initialize_dynamic_commands(self):
             for action_name, action_handler in self.model.sim_actions.items():

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -251,29 +251,33 @@ def get_tango_device_server(model, sim_data_files):
                                 try:
                                     adjustable_val = sim_quantity_meta_info['value']
                                 except KeyError:
-                                    adjustable_val = sim_quantity_meta_info['possiblevalues']
+                                    adjustable_val = sim_quantity_meta_info[
+                                                        'possiblevalues']
                                 if attr_data_format == 'SCALAR':
                                     adjustable_val = val_type(adjustable_val)
                                 elif attr_data_format == 'SPECTRUM':
                                     adjustable_val = map(val_type, adjustable_val)
                                 else:
-                                    adjustable_val = [[val_type(curr_val) for curr_val in sublist]
-                                                    for sublist in adjustable_val]
+                                    adjustable_val = [[val_type(curr_val) for curr_val in
+                                                      sublist] for sublist in 
+                                                      adjustable_val]
                             else:
                                 if attr_data_format == 'SCALAR':
                                     adjustable_val = val
                                 elif attr_data_format == 'SPECTRUM':
                                     adjustable_val = [val] * max_dim_x
                                 else:
-                                    adjustable_val = [[val] * max_dim_x for i in range(max_dim_y)]
+                                    adjustable_val = [[val] * max_dim_x 
+                                                      for i in range(max_dim_y)]
                         else:
-                            if sim_quantity_meta_info['quantity_simulation_type'] == 'ConstantQuantity':
+                            if (sim_quantity_meta_info['quantity_simulation_type'] ==
+                                'ConstantQuantity'):
                                 try:
                                     initial_value = sim_quantity_meta_info['initial_value']
                                 except KeyError:
                                     initial_value = None
-                                adjustable_val = (initial_value if initial_value not in [None, ""]
-                                                  else val)
+                                adjustable_val = (initial_value if initial_value not in
+                                                  [None, ""] else val)
                                 if val_type is None:
                                     adjustable_val = None
                                 else:

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -214,32 +214,39 @@ def get_tango_device_server(model, sim_data_files):
             simulated_quantities = self.model.sim_quantities.values()
             for simulated_quantity in simulated_quantities:
                 sim_quantity_meta_info = simulated_quantity.meta
+                key_vals = sim_quantity_meta_info.keys()
                 attr_data_type = sim_quantity_meta_info['data_type']
-                attr_data_format = str(sim_quantity_meta_info['data_format'])
                 try:
-                    max_dim_x = sim_quantity_meta_info['max_dim_x']
-                    max_dim_y = sim_quantity_meta_info['max_dim_y']
+                    attr_data_format = str(sim_quantity_meta_info['data_format'])
                 except KeyError:
-                    max_dim_x = sim_quantity_meta_info['maxX']
-                    max_dim_y = sim_quantity_meta_info['maxY']
-                if not max_dim_x:
+                    attr_data_format = 'SPECTRUM'
+                # attr_data_format = str(sim_quantity_meta_info['data_format'])
+                expected_key_vals = ['max_dim_x', 'max_dim_y']
+                if any(key_val in expected_key_vals for key_val in key_vals):
+                    try:
+                        max_dim_x = sim_quantity_meta_info['max_dim_x']
+                        max_dim_y = sim_quantity_meta_info['max_dim_y']
+                    except KeyError:
+                        max_dim_x = sim_quantity_meta_info['maxX']
+                        max_dim_y = sim_quantity_meta_info['maxY']
+                    if not max_dim_x:
+                        max_dim_x = 1
+                    if not max_dim_y:
+                        max_dim_y = 2
+                else:
                     max_dim_x = 1
-                if not max_dim_y:
                     max_dim_y = 2
+
                 val_type, val = INITIAL_CONSTANT_VALUE_TYPES[attr_data_type]
+                expected_key_vals = ['value', 'possiblevalues']
                 try:
                     sim_quantity_meta_info['quantity_simulation_type']
                 except KeyError:
-                    try:
-                        adjustable_val = sim_quantity_meta_info['value']
-                    except KeyError:
-                        if attr_data_format == 'SCALAR':
-                            adjustable_val = val
-                        elif attr_data_format == 'SPECTRUM':
-                            adjustable_val = [val] * max_dim_x
-                        else:
-                            adjustable_val = [[val] * max_dim_x for i in range(max_dim_y)]
-                    else:
+                    if any(key_val in expected_key_vals for key_val in key_vals):
+                        try:
+                            adjustable_val = sim_quantity_meta_info['value']
+                        except KeyError:
+                            adjustable_val = sim_quantity_meta_info['possiblevalues']
                         if attr_data_format == 'SCALAR':
                             adjustable_val = val_type(adjustable_val)
                         elif attr_data_format == 'SPECTRUM':
@@ -247,6 +254,14 @@ def get_tango_device_server(model, sim_data_files):
                         else:
                             adjustable_val = [[val_type(curr_val) for curr_val in sublist]
                                 for sublist in adjustable_val]
+                    else:
+                        if attr_data_format == 'SCALAR':
+                            adjustable_val = val
+                        elif attr_data_format == 'SPECTRUM':
+                            adjustable_val = [val] * max_dim_x
+                        else:
+                            adjustable_val = [[val] * max_dim_x for i in range(max_dim_y)]
+                    
                     simulated_quantity.last_val = adjustable_val
                 else:
                     if sim_quantity_meta_info['quantity_simulation_type'] == 'ConstantQuantity':

--- a/tango_simlib/tests/test_sim_test_interface.py
+++ b/tango_simlib/tests/test_sim_test_interface.py
@@ -375,7 +375,6 @@ class test_TangoSimGenDeviceIntegration(ClassCleanupUnittestMixin, unittest.Test
         # reading the attribute value. So instead we use the sleep method to allow for
         # 'dt' to be large enough.
         time.sleep(1)
-        print self.sim_device.read_attribute('rainfall').value
         self.assertGreater(getattr(self.sim_device.read_attribute('rainfall'), 'value'),
                            max_rainfall_value,
                            "Rain levels not above the expected value for a rainstorm")

--- a/tango_simlib/tests/test_sim_test_interface.py
+++ b/tango_simlib/tests/test_sim_test_interface.py
@@ -317,7 +317,7 @@ class test_TangoSimGenDeviceIntegration(ClassCleanupUnittestMixin, unittest.Test
 
     def test_StopRainfall_command(self):
         command_name = 'StopRainfall'
-        expected_rainfall_value = 0.0
+        expected_rainfall_value = 1.5
         self.sim_control_device.command_inout(command_name)
         # TODO (KM 17-02-2018) Follow up on this issue:
         # https://skaafrica.atlassian.net/browse/LMC-64 for testing two dependent TANGO
@@ -337,8 +337,8 @@ class test_TangoSimGenDeviceIntegration(ClassCleanupUnittestMixin, unittest.Test
         """Testing that the Tango device weather simulation of quantities can be halted.
         """
         command_name = 'StopQuantitySimulation'
-        expected_result = {'temperature': 0.0,
-                           'insolation': 0.0}
+        expected_result = {'temperature': 25.0,
+                           'insolation': 500.0}
         device_attributes = self.sim_device.get_attribute_list()
         for quantity_name in expected_result.keys():
             self.assertIn(quantity_name, device_attributes)

--- a/tango_simlib/tests/test_sim_test_interface.py
+++ b/tango_simlib/tests/test_sim_test_interface.py
@@ -317,7 +317,7 @@ class test_TangoSimGenDeviceIntegration(ClassCleanupUnittestMixin, unittest.Test
 
     def test_StopRainfall_command(self):
         command_name = 'StopRainfall'
-        expected_rainfall_value = 1.5
+        expected_rainfall_value = 0.0
         self.sim_control_device.command_inout(command_name)
         # TODO (KM 17-02-2018) Follow up on this issue:
         # https://skaafrica.atlassian.net/browse/LMC-64 for testing two dependent TANGO
@@ -337,8 +337,8 @@ class test_TangoSimGenDeviceIntegration(ClassCleanupUnittestMixin, unittest.Test
         """Testing that the Tango device weather simulation of quantities can be halted.
         """
         command_name = 'StopQuantitySimulation'
-        expected_result = {'temperature': 25.0,
-                           'insolation': 500.0}
+        expected_result = {'temperature': 0.0,
+                           'insolation': 0.0}
         device_attributes = self.sim_device.get_attribute_list()
         for quantity_name in expected_result.keys():
             self.assertIn(quantity_name, device_attributes)
@@ -375,6 +375,7 @@ class test_TangoSimGenDeviceIntegration(ClassCleanupUnittestMixin, unittest.Test
         # reading the attribute value. So instead we use the sleep method to allow for
         # 'dt' to be large enough.
         time.sleep(1)
+        print self.sim_device.read_attribute('rainfall').value
         self.assertGreater(getattr(self.sim_device.read_attribute('rainfall'), 'value'),
                            max_rainfall_value,
                            "Rain levels not above the expected value for a rainstorm")


### PR DESCRIPTION
On startup of the simulator, the `last_val` attribute assumes value of 0.0 instead of using the default values of attributes specified in the data file(s). The fix is to use existing values from data file is there's any or initialise it to a default value with the right type.

JIRA ticket: [CB-3075](https://skaafrica.atlassian.net/browse/CB-3075)