### PR TITLE
registering devices for no db option

### DIFF
--- a/tango_simlib/tango_launcher.py
+++ b/tango_simlib/tango_launcher.py
@@ -63,11 +63,10 @@ def put_device_property(dev_name, property_name, property_value, file_name):
 def start_device(opts):
     server_name = os.path.basename(opts.server_command)
     number_of_devices = len(opts.name)
-    # Register tango devices if TANGO DB is being used
-    if opts.file_name:
-        for i in range(number_of_devices):
-            register_device(
-                opts.name[i], opts.device_class[i], server_name, opts.server_instance)
+    # Register tango devices
+    for i in range(number_of_devices):
+        register_device(
+            opts.name[i], opts.device_class[i], server_name, opts.server_instance)
     for dev_property in opts.device_properties:
         try:
             dev_name, dev_property_name, dev_property_val = dev_property.split(

--- a/tango_simlib/tango_launcher.py
+++ b/tango_simlib/tango_launcher.py
@@ -64,7 +64,7 @@ def start_device(opts):
     server_name = os.path.basename(opts.server_command)
     number_of_devices = len(opts.name)
     # Register tango devices if TANGO DB is being used
-    if not opts.file_name:
+    if opts.file_name:
         for i in range(number_of_devices):
             register_device(
                 opts.name[i], opts.device_class[i], server_name, opts.server_instance)

--- a/tango_simlib/tango_launcher.py
+++ b/tango_simlib/tango_launcher.py
@@ -56,15 +56,16 @@ def put_device_property(dev_name, property_name, property_value, db):
     db.put_device_property(dev_name, {property_name:[property_value]})
 
 def start_device(opts):
-    db = tango.Database()
-    server_name = os.path.basename(opts.server_command)
-    number_of_devices = len(opts.name)
-    # Register tango devices
-    for i in range(number_of_devices):
-        register_device(
-            opts.name[i], opts.device_class[i], server_name, opts.server_instance, db)
     if opts.file_name:
         db = tango.Database(opts.file_name)
+    else:
+        db = tango.Database()
+        server_name = os.path.basename(opts.server_command)
+        number_of_devices = len(opts.name)
+        # Register tango devices
+        for i in range(number_of_devices):
+            register_device(
+                opts.name[i], opts.device_class[i], server_name, opts.server_instance, db)
     for dev_property in opts.device_properties:
         try:
             dev_name, dev_property_name, dev_property_val = dev_property.split(

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -457,7 +457,11 @@ def configure_device_model(sim_data_file=None, test_device_name=None):
 
     if test_device_name is None:
         server_name = helper_module.get_server_name()
-        db_instance = Database()
+        file_name = helper_module.get_file_name()
+        if file_name:
+            db_instance = Database(file_name)
+        else:
+            db_instance = Database()
         # db_datum is a PyTango.DbDatum structure with attribute name and value_string.
         # The name attribute represents the name of the device server and the
         # value_string attribute is a list of all the registered device instances in

--- a/tango_simlib/utilities/helper_module.py
+++ b/tango_simlib/utilities/helper_module.py
@@ -81,6 +81,17 @@ def get_server_name():
     server_name = executable_name + '/' + sys.argv[1]
     return server_name
 
+def get_file_name():
+    """Gets the db file name from the command line arguments
+
+    Returns
+    -------
+    file_name : str
+        file used as tango database
+    """
+    file_name = sys.argv[4].split('=')[1]
+    return file_name
+
 def append_device_to_db_file(server, instance, device, db_file_name,
                              tangoclass=None, properties={}):
     """Generate a database file corresponding to the given arguments."""

--- a/tango_simlib/utilities/helper_module.py
+++ b/tango_simlib/utilities/helper_module.py
@@ -91,7 +91,7 @@ def get_file_name():
     """
     args = sys.argv
     for index, val in enumerate(args):
-        if 'file' in val:
+        if val.startswith('-file='):
             return args[index].split('=')[1]
         else:
             return None

--- a/tango_simlib/utilities/helper_module.py
+++ b/tango_simlib/utilities/helper_module.py
@@ -89,8 +89,12 @@ def get_file_name():
     file_name : str
         file used as tango database
     """
-    file_name = sys.argv[4].split('=')[1]
-    return file_name
+    args = sys.argv
+    for index, val in enumerate(args):
+        if 'file' in val:
+            return args[index].split('=')[1]
+        else:
+            return None
 
 def append_device_to_db_file(server, instance, device, db_file_name,
                              tangoclass=None, properties={}):


### PR DESCRIPTION
There is no need to register devices when using a file as the db. The current implementation in `tango_launcher` tried to fetch the device list from the real tango DB and went on to start the device server using a default test name `test/nodb/tangodeviceserver` which does not match devices registered in the file.
### current implementation
https://github.com/ska-sa/tango-simlib/blob/b72e486a1eff97bdb9dae6f469600c355f30e9d1/tango_simlib/tango_sim_generator.py#L460-L477

This PR addresses the run time error encountered (image below) when the [kat-tango-sim-launcher](https://github.com/ska-sa/katsim/blob/master/scripts/kat-tango-sim-launcher.py) script executes.

<img width="1424" alt="screen shot 2018-07-26 at 07 36 13" src="https://user-images.githubusercontent.com/37175409/43243342-9e4dd11c-90a6-11e8-8158-717eed80f9d9.png">