### PR TITLE
correcting bug in get_file_name function

### DIFF
--- a/tango_simlib/utilities/helper_module.py
+++ b/tango_simlib/utilities/helper_module.py
@@ -89,12 +89,10 @@ def get_file_name():
     file_name : str
         file used as tango database
     """
-    args = sys.argv
-    for index, val in enumerate(args):
+    for val in sys.argv:
         if val.startswith('-file='):
-            return args[index].split('=')[1]
-        else:
-            return None
+            return val.split('=')[1]
+    return None
 
 def append_device_to_db_file(server, instance, device, db_file_name,
                              tangoclass=None, properties={}):


### PR DESCRIPTION
This implementation always returns `None` since the loop stops on the first iteration. The update corrects this bug and ensure the right value is returned.

JIRA ticket: [MT-22](https://skaafrica.atlassian.net/browse/MT-22)