### PR TITLE
Run device server using file or real database

### DIFF
--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -397,7 +397,8 @@ def write_device_properties_to_db(device_name, model, db_instance=None):
         Tango database instance
     """
     if not db_instance:
-        db_instance = Database()
+        db_instance = helper_module.get_database()
+
     for prop_name, prop_meta in model.sim_properties.items():
         db_instance.put_device_property(
             device_name, {prop_name: prop_meta['DefaultPropValue']})
@@ -457,11 +458,7 @@ def configure_device_model(sim_data_file=None, test_device_name=None):
 
     if test_device_name is None:
         server_name = helper_module.get_server_name()
-        file_name = helper_module.get_file_name()
-        if file_name:
-            db_instance = Database(file_name)
-        else:
-            db_instance = Database()
+        db_instance = helper_module.get_database()
         # db_datum is a PyTango.DbDatum structure with attribute name and value_string.
         # The name attribute represents the name of the device server and the
         # value_string attribute is a list of all the registered device instances in

--- a/tango_simlib/utilities/helper_module.py
+++ b/tango_simlib/utilities/helper_module.py
@@ -81,18 +81,19 @@ def get_server_name():
     server_name = executable_name + '/' + sys.argv[1]
     return server_name
 
-def get_file_name():
-    """Gets the db file name from the command line arguments
+def get_database():
+    """Gets the tango db.
 
     Returns
     -------
-    file_name : str
-        file used as tango database
+    db : tango.Database
+        A tango database instance
     """
     for val in sys.argv:
         if val.startswith('-file='):
-            return val.split('=')[1]
-    return None
+            file_name = val.split('=')[1]
+            return Database(file_name)
+    return Database()
 
 def append_device_to_db_file(server, instance, device, db_file_name,
                              tangoclass=None, properties={}):


### PR DESCRIPTION
**Run device server using file or real database**

The `write_device_properties_to_db` was creating an instance of the database by connecting to the real database server. This is not something we want to do everytime, as we want to run a tango device using a file as a database (for the _mkat-rts_ configuration).

I also changed the `get_file_name` utililty function to `get_database`. It now returns the tango database instance.

JIRA: [MT-145](https://skaafrica.atlassian.net/browse/MT-145)

