### PR TITLE
Add missing data types to fix startup issues

### DIFF
--- a/tango_simlib/model.py
+++ b/tango_simlib/model.py
@@ -44,7 +44,9 @@ INITIAL_CONSTANT_VALUE_TYPES = {
     CmdArgType.DevLong64: (int, 0),
     CmdArgType.DevULong64: (int, 0),
     CmdArgType.DevVoid: (None, None),
-    CmdArgType.DevState: (int, 0)}
+    CmdArgType.DevState: (int, 0),
+    CmdArgType.DevEncoded: (bytearray, 0)
+}
 
 
 class Model(object):

--- a/tango_simlib/model.py
+++ b/tango_simlib/model.py
@@ -1,4 +1,4 @@
-######################################################################################### 
+#########################################################################################
 # Copyright 2017 SKA South Africa (http://ska.ac.za/)                                   #
 #                                                                                       #
 # BSD license - see LICENSE.txt for details                                             #
@@ -36,8 +36,13 @@ INITIAL_CONSTANT_VALUE_TYPES = {
     CmdArgType.DevDouble: (float, 0.0),
     CmdArgType.DevBoolean: (bool, False),
     CmdArgType.DevEnum: (int, 0),
+    CmdArgType.DevUChar: (int, 0),
+    CmdArgType.DevShort: (int, 0),
+    CmdArgType.DevUShort: (int, 0),
     CmdArgType.DevLong: (int, 0),
     CmdArgType.DevULong: (int, 0),
+    CmdArgType.DevLong64: (int, 0),
+    CmdArgType.DevULong64: (int, 0),
     CmdArgType.DevVoid: (None, None),
     CmdArgType.DevState: (int, 0)}
 
@@ -109,10 +114,10 @@ class Model(object):
                 "Sim {} skipping update at {}, dt {} < {} and pause {}"
                 .format(self.name, sim_time, dt, self.min_update_period, self.paused))
             return
-        
+
         for override_update in self.override_pre_updates:
             override_update(self, sim_time, dt)
-            
+
         MODULE_LOGGER.info("Stepping at {}, dt: {}".format(sim_time, dt))
         self.last_update_time = sim_time
         try:
@@ -296,7 +301,7 @@ class PopulateModelQuantities(object):
                         max_dim_x = 1
                     if not max_dim_y:
                         max_dim_y = 2
-                
+
                 val_type, val = INITIAL_CONSTANT_VALUE_TYPES[attr_data_type]
                 expected_key_vals = ['value', 'possiblevalues']
                 if any(key_val in expected_key_vals for key_val in key_vals):
@@ -368,7 +373,7 @@ class PopulateModelActions(object):
     cmd_info : dict
         A dictionary of all the device commands together with their
         metadata specified in the xmi, json or fgo file(s).
-    
+
     override_info : dict
         A dictionary of device override info in specified the xmi, json or fgo file(s).
 
@@ -590,7 +595,7 @@ class PopulateModelProperties(object):
     Attributes
     ----------
     properties_info : dict
-        A dictionary of device property configuration specified in the xmi, json 
+        A dictionary of device property configuration specified in the xmi, json
         or fgo file(s).
     sim_model :  Model instance
         An instance of the Model class which is used for simulation of simple attributes.


### PR DESCRIPTION
Simulated servers that use data types like DevUShort fail to start up.  Fix this by adding the missing types.

Example of the problem:
```
$ SvrSimPdu A
Traceback (most recent call last):
  File "/usr/local/bin/SvrSimPdu", line 16, in <module>
    main()
  File "/usr/local/bin/SvrSimPdu", line 11, in main
    model = configure_device_model(sim_data_files)
  File "/usr/local/lib/python2.7/dist-packages/tango_simlib/tango_sim_generator.py", line 491, in configure_device_model
    PopulateModelQuantities(parser, dev_name, model)
  File "/usr/local/lib/python2.7/dist-packages/tango_simlib/model.py", line 185, in __init__
    self.setup_sim_quantities()
  File "/usr/local/lib/python2.7/dist-packages/tango_simlib/model.py", line 300, in setup_sim_quantities
    val_type, val = INITIAL_CONSTANT_VALUE_TYPES[attr_data_type]
KeyError: tango._tango.CmdArgType.DevUShort
```