### PR TITLE
Handle non scalar values

### DIFF
--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -249,7 +249,7 @@ def get_tango_device_server(model, sim_data_files):
                 adjustable_attrs = simulated_quantity.adjustable_attributes
                 for attr in adjustable_attrs:
                     if attr == 'last_update_time':
-                        simulated_quantity.attr = model_time
+                        setattr(simulated_quantity, attr, model_time)
                         continue
                     else:
                         try:
@@ -293,23 +293,13 @@ def get_tango_device_server(model, sim_data_files):
                                     adjustable_val = val_type(adjustable_val)
                             else:
                                 if attr == 'last_val':
-                                    simulated_quantity.attr = float(sim_quantity_meta_info['mean'])
+                                    setattr(simulated_quantity, attr,
+                                            float(sim_quantity_meta_info['mean']))
                                     continue
                                 else:
                                     adjustable_val = float(sim_quantity_meta_info[attr])
 
-                        if attr == 'last_val':
-                            simulated_quantity.last_val = adjustable_val
-                        elif attr == 'mean':
-                            simulated_quantity.mean = adjustable_val
-                        elif attr == 'std_dev':
-                            simulated_quantity.std_dev = adjustable_val
-                        elif attr == 'max_slew_rate':
-                            simulated_quantity.max_slew_rate = adjustable_val
-                        elif attr == 'min_bound':
-                            simulated_quantity.min_bound = adjustable_val
-                        elif attr == 'max_bound':
-                            simulated_quantity.max_bound = adjustable_val
+                        setattr(simulated_quantity, attr, adjustable_val)
 
         def initialize_dynamic_commands(self):
             for action_name, action_handler in self.model.sim_actions.items():

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -133,7 +133,7 @@ def get_tango_device_server(model, sim_data_files):
             # For attributes that have a SPECTRUM data format, there is no need to
             # type cast them to an integer data type. we need assign the list of values
             # to the attribute value parameter.
-            if type(value) == list or isinstance(value, np.ndarray):
+            if type(value) in (list, np.ndarray):
                 attr.set_value_date_quality(value, update_time, quality)
             else:
                 attr.set_value_date_quality(int(value), update_time, quality)

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -153,7 +153,7 @@ def get_tango_device_server(model, sim_data_files):
             else:
                 attr.set_value_date_quality(int(value), update_time, quality)
         # Attribute write method for writable attributes
-        if str(attr_meta['writable']) == 'READ_WRITE':
+        if str(attr_meta['writable']) in ('READ_WRITE', 'WRITE'):
             @attr.write
             def attr(tango_device_instance, new_val):
                 # When selecting a model quantity we use the enum labels list indexing
@@ -369,8 +369,8 @@ def get_tango_device_server(model, sim_data_files):
 
                     if rw_type in (AttrWriteType.READ, AttrWriteType.READ_WITH_WRITE):
                         self.add_attribute(attr, self.read_attributes)
-                    if rw_type == AttrWriteType.WRITE:
-                        self.add_attribute(attr, self.write_attributes)
+                    elif rw_type == AttrWriteType.WRITE:
+                        self.add_attribute(attr, w_meth=self.write_attributes)
                     elif rw_type == AttrWriteType.READ_WRITE:
                         self.add_attribute(
                             attr, self.read_attributes, self.write_attributes)

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -365,11 +365,14 @@ def get_tango_device_server(model, sim_data_files):
                             MODULE_LOGGER.info(
                                 "No setter function for " + prop + " property")
                     attr.set_default_properties(attr_props)
+
                     if rw_type == AttrWriteType.READ:
                         self.add_attribute(attr, self.read_attributes)
-                    else:
+                    elif rw_type in (AttrWriteType.READ_WRITE,
+                                     AttrWriteType.READ_WITH_WRITE, AttrWriteType.WRITE):
                         self.add_attribute(
                             attr, self.read_attributes, self.write_attributes)
+
                     MODULE_LOGGER.info("Added dynamic {} attribute"
                                        .format(attribute_name))
 

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -63,6 +63,20 @@ class TangoDeviceServerBase(Device):
             self.info_stream("Reading attribute %s", name)
             attr.set_value_date_quality(value, update_time, quality)
 
+    def write_attributes(self, attr):
+        """Method writing an attribute value
+
+        Parameters
+        ----------
+        attr : PyTango.DevAttr
+            The attribute to write to.
+
+        """
+        name = attr.get_name()
+        data = attr.get_write_value()
+        self.info_stream("Writing attribute {} with value: {}".format(name, data))
+        self.model.sim_quantity[name].set_val(data, self.model.time_func())
+
 
 def get_tango_device_server(model, sim_data_files):
     """Declares a tango device class that inherits the Device class and then
@@ -351,7 +365,11 @@ def get_tango_device_server(model, sim_data_files):
                             MODULE_LOGGER.info(
                                 "No setter function for " + prop + " property")
                     attr.set_default_properties(attr_props)
-                    self.add_attribute(attr, self.read_attributes)
+                    if rw_type == tango._tango.AttrWriteType.READ:
+                        self.add_attribute(attr, self.read_attributes)
+                    else:
+                        self.add_attribute(
+                            attr, self.read_attributes, self.write_attributes)
                     MODULE_LOGGER.info("Added dynamic {} attribute"
                                        .format(attribute_name))
 

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -365,7 +365,7 @@ def get_tango_device_server(model, sim_data_files):
                             MODULE_LOGGER.info(
                                 "No setter function for " + prop + " property")
                     attr.set_default_properties(attr_props)
-                    if rw_type == tango._tango.AttrWriteType.READ:
+                    if rw_type == AttrWriteType.READ:
                         self.add_attribute(attr, self.read_attributes)
                     else:
                         self.add_attribute(

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -298,8 +298,18 @@ def get_tango_device_server(model, sim_data_files):
                                 else:
                                     adjustable_val = float(sim_quantity_meta_info[attr])
 
-                        simulated_quantity.attr = adjustable_val
-                
+                        if attr == 'last_val':
+                            simulated_quantity.last_val = adjustable_val
+                        elif attr == 'mean':
+                            simulated_quantity.mean = adjustable_val
+                        elif attr == 'std_dev':
+                            simulated_quantity.std_dev = adjustable_val
+                        elif attr == 'max_slew_rate':
+                            simulated_quantity.max_slew_rate = adjustable_val
+                        elif attr == 'min_bound':
+                            simulated_quantity.min_bound = adjustable_val
+                        elif attr == 'max_bound':
+                            simulated_quantity.max_bound = adjustable_val
 
         def initialize_dynamic_commands(self):
             for action_name, action_handler in self.model.sim_actions.items():

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -75,7 +75,7 @@ class TangoDeviceServerBase(Device):
         name = attr.get_name()
         data = attr.get_write_value()
         self.info_stream("Writing attribute {} with value: {}".format(name, data))
-        self.model.sim_quantity[name].set_val(data, self.model.time_func())
+        self.model.sim_quantities[name].set_val(data, self.model.time_func())
 
 
 def get_tango_device_server(model, sim_data_files):

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -264,7 +264,7 @@ def get_tango_device_server(model, sim_data_files):
                 adjustable_attrs = simulated_quantity.adjustable_attributes
                 for attr in adjustable_attrs:
                     if attr == 'last_update_time':
-                        setattr(simulated_quantity, attr, model_time)
+                        simulated_quantity.last_update_time = model_time
                         continue
                     else:
                         try:
@@ -308,8 +308,8 @@ def get_tango_device_server(model, sim_data_files):
                                     adjustable_val = val_type(adjustable_val)
                             else:
                                 if attr == 'last_val':
-                                    setattr(simulated_quantity, attr,
-                                            float(sim_quantity_meta_info['mean']))
+                                    simulated_quantity.last_val = (
+                                        float(sim_quantity_meta_info['mean']))
                                     continue
                                 else:
                                     adjustable_val = float(sim_quantity_meta_info[attr])

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -16,6 +16,7 @@ import argparse
 import time
 
 from functools import partial
+import numpy as np
 
 from tango import (Attr, AttrDataFormat, AttrQuality, AttrWriteType, CmdArgType,
                    Database, DevState, UserDefaultAttrProp)
@@ -132,7 +133,7 @@ def get_tango_device_server(model, sim_data_files):
             # For attributes that have a SPECTRUM data format, there is no need to
             # type cast them to an integer data type. we need assign the list of values
             # to the attribute value parameter.
-            if type(value) == list:
+            if type(value) == list or isinstance(value, np.ndarray):
                 attr.set_value_date_quality(value, update_time, quality)
             else:
                 attr.set_value_date_quality(int(value), update_time, quality)

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -60,7 +60,7 @@ class TangoDeviceServerBase(Device):
             name = attr.get_name()
             value, update_time = self.model.quantity_state[name]
             quality = AttrQuality.ATTR_VALID
-            self.info_stream("Reading attribute %s", name)
+            self.debug_stream("Reading attribute %s", name)
             attr.set_value_date_quality(value, update_time, quality)
 
     def write_attributes(self, attr):
@@ -72,10 +72,11 @@ class TangoDeviceServerBase(Device):
             The attribute to write to.
 
         """
-        name = attr.get_name()
-        data = attr.get_write_value()
-        self.info_stream("Writing attribute {} with value: {}".format(name, data))
-        self.model.sim_quantities[name].set_val(data, self.model.time_func())
+        if self.get_state() != DevState.OFF:
+            name = attr.get_name()
+            data = attr.get_write_value()
+            self.debug_stream("Writing attribute {} with value: {}".format(name, data))
+            self.model.sim_quantities[name].set_val(data, self.model.time_func())
 
 
 def get_tango_device_server(model, sim_data_files):

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -367,10 +367,11 @@ def get_tango_device_server(model, sim_data_files):
                                 "No setter function for " + prop + " property")
                     attr.set_default_properties(attr_props)
 
-                    if rw_type == AttrWriteType.READ:
+                    if rw_type in (AttrWriteType.READ, AttrWriteType.READ_WITH_WRITE):
                         self.add_attribute(attr, self.read_attributes)
-                    elif rw_type in (AttrWriteType.READ_WRITE,
-                                     AttrWriteType.READ_WITH_WRITE, AttrWriteType.WRITE):
+                    if rw_type == AttrWriteType.WRITE:
+                        self.add_attribute(attr, self.write_attributes)
+                    elif rw_type == AttrWriteType.READ_WRITE:
                         self.add_attribute(
                             attr, self.read_attributes, self.write_attributes)
 

--- a/tango_simlib/tests/config_files/Weather.xmi
+++ b/tango_simlib/tests/config_files/Weather.xmi
@@ -159,7 +159,7 @@
       <eventCriteria relChange="10" absChange="0.5" period="1000"/>
       <evArchiveCriteria relChange="10" absChange="0.5" period="1000"/>
     </dynamicAttributes>
-    <dynamicAttributes name="integer1" attType="Scalar" rwType="READ" displayLevel="OPERATOR" polledPeriod="1000" maxX="" maxY="" allocReadMember="true" isDynamic="true">
+    <dynamicAttributes name="integer1" attType="Scalar" rwType="READ_WRITE" displayLevel="OPERATOR" polledPeriod="1000" maxX="" maxY="" allocReadMember="true" isDynamic="true">
       <dataType xsi:type="pogoDsl:IntType"/>
       <changeEvent fire="false" libCheckCriteria="false"/>
       <archiveEvent fire="false" libCheckCriteria="false"/>

--- a/tango_simlib/tests/config_files/devenum_test_case.xmi
+++ b/tango_simlib/tests/config_files/devenum_test_case.xmi
@@ -29,6 +29,15 @@
       <properties description="The achieved pointing of the DSH Element. [timestamp] Milliseconds since UNIX epoch, UTC ms [Azimuth] degree [Elevation] degree" label="Achieved pointing" unit="[ms, degree, degree]" standardUnit="" displayUnit="" format="" maxValue="" minValue="" maxAlarm="" minAlarm="" maxWarning="" minWarning="" deltaTime="" deltaValue=""/>
       <eventCriteria relChange="" absChange="" period="1000"/>
     </attributes>
+    <attributes name="desiredPointing" attType="Spectrum" rwType="READ" displayLevel="OPERATOR" polledPeriod="0" maxX="7" maxY="" allocReadMember="true" isDynamic="false">
+      <dataType xsi:type="pogoDsl:FloatType"/>
+      <changeEvent fire="false" libCheckCriteria="false"/>
+      <archiveEvent fire="false" libCheckCriteria="false"/>
+      <dataReadyEvent fire="false" libCheckCriteria="true"/>
+      <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
+      <properties description="The desired pointing of the DSH Element. [timestamp] Milliseconds since UNIX epoch, UTC ms [Azimuth] degree [Elevation] degree [Azimuth speed] degrees/s [Elevation speed] degrees/s [Azimuth acceleration] degrees/s^-2 [Elevation acceleration] degrees/s^-2" label="Desired pointing" unit="[ms, degree, degree]" standardUnit="" displayUnit="" format="" maxValue="" minValue="" maxAlarm="" minAlarm="" maxWarning="" minWarning="" deltaTime="" deltaValue=""/>
+      <eventCriteria relChange="" absChange="" period="1000"/>
+    </attributes>
     <preferences docHome="./doc_html" makefileHome="/usr/share/pogo/preferences"/>
   </classes>
 </pogoDsl:PogoSystem>

--- a/tango_simlib/tests/config_files/devenum_test_case.xmi
+++ b/tango_simlib/tests/config_files/devenum_test_case.xmi
@@ -29,7 +29,7 @@
       <properties description="The achieved pointing of the DSH Element. [timestamp] Milliseconds since UNIX epoch, UTC ms [Azimuth] degree [Elevation] degree" label="Achieved pointing" unit="[ms, degree, degree]" standardUnit="" displayUnit="" format="" maxValue="" minValue="" maxAlarm="" minAlarm="" maxWarning="" minWarning="" deltaTime="" deltaValue=""/>
       <eventCriteria relChange="" absChange="" period="1000"/>
     </attributes>
-    <attributes name="desiredPointing" attType="Spectrum" rwType="READ" displayLevel="OPERATOR" polledPeriod="0" maxX="7" maxY="" allocReadMember="true" isDynamic="false">
+    <attributes name="desiredPointing" attType="Spectrum" rwType="READ_WRITE" displayLevel="OPERATOR" polledPeriod="0" maxX="7" maxY="" allocReadMember="true" isDynamic="false">
       <dataType xsi:type="pogoDsl:FloatType"/>
       <changeEvent fire="false" libCheckCriteria="false"/>
       <archiveEvent fire="false" libCheckCriteria="false"/>

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -670,9 +670,9 @@ class test_XmiStaticAttributes(ClassCleanupUnittestMixin, unittest.TestCase):
         el_speed = 0.0
         az_accl = 0.0
         el_accl = 0.0
-        self.assertListEqual(self.device.desiredPointing,
-                             np.asarray([_timestamp, az, el, az_speed,
-                                         el_speed, az_accl, el_accl], dtype=np.float32))
+        self.assertListEqual(self.device.desiredPointing.tolist(),
+                             [_timestamp, az, el, az_speed,
+                              el_speed, az_accl, el_accl])
 
         # Change the values of the timestamp,  az and el
         _timestamp = time.time()
@@ -683,6 +683,6 @@ class test_XmiStaticAttributes(ClassCleanupUnittestMixin, unittest.TestCase):
             _timestamp, az, el, az_speed, el_speed, az_accl, el_accl
         ]
 
-        self.assertListEqual(self.device.desiredPointing,
-                             np.asarray([_timestamp, az, el, az_speed,
-                                         el_speed, az_accl, el_accl], dtype=np.float32))
+        self.assertListEqual(self.device.desiredPointing.tolist(),
+                             [_timestamp, az, el, az_speed,
+                              el_speed, az_accl, el_accl])

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -658,3 +658,15 @@ class test_XmiStaticAttributes(ClassCleanupUnittestMixin, unittest.TestCase):
                                  "The expected value for the device property "
                                  "parameter '%s' does not match with the "
                                  "actual value" % (attr_prop))
+
+    def test_writable_spectrum_attribute(self):
+        """Test that the Spectrum writable attribute can be set correctly."""
+        timestamp = 0.0
+        az = 0.0
+        el = 0.0
+        az_speed = 0.0
+        el_speed = 0.0
+        az_accl = 0.0
+        el_accl = 0.0
+        self.assertEqual(self.device.desiredPosition, [timestamp, az, el, az_speed,
+                                                       el_speed, az_accl, el_accl])

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -675,7 +675,7 @@ class test_XmiStaticAttributes(ClassCleanupUnittestMixin, unittest.TestCase):
                               el_speed, az_accl, el_accl])
 
         # Change the values of the timestamp,  az and el
-        _timestamp = time.time()
+        _timestamp = 124324
         az = 45.0
         el = 104.0
         # Write to the attribute desiredPointing

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -6,6 +6,7 @@
 #########################################################################################
 import mock
 import logging
+import time
 import unittest
 import pkg_resources
 
@@ -661,12 +662,24 @@ class test_XmiStaticAttributes(ClassCleanupUnittestMixin, unittest.TestCase):
 
     def test_writable_spectrum_attribute(self):
         """Test that the Spectrum writable attribute can be set correctly."""
-        timestamp = 0.0
+        _timestamp = 0.0
         az = 0.0
         el = 0.0
         az_speed = 0.0
         el_speed = 0.0
         az_accl = 0.0
         el_accl = 0.0
-        self.assertEqual(self.device.desiredPosition, [timestamp, az, el, az_speed,
+        self.assertEqual(self.device.desiredPointing, [_timestamp, az, el, az_speed,
+                                                       el_speed, az_accl, el_accl])
+
+        # Change the values of az and el
+        _timestamp = time.time()
+        az = 45.0
+        el = 104.0
+        # Write to the attribute desiredPointing
+        self.device.desiredPointing = [
+            _timestamp, az, el, az_speed, el_speed, az_accl, el_accl
+        ]
+
+        self.assertEqual(self.device.desiredPointing, [_timestamp, az, el, az_speed,
                                                        el_speed, az_accl, el_accl])

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -6,6 +6,7 @@
 #########################################################################################
 import mock
 import logging
+import numpy as np
 import time
 import unittest
 import pkg_resources
@@ -669,8 +670,9 @@ class test_XmiStaticAttributes(ClassCleanupUnittestMixin, unittest.TestCase):
         el_speed = 0.0
         az_accl = 0.0
         el_accl = 0.0
-        self.assertListEqual(self.device.desiredPointing[0], [_timestamp, az, el, az_speed,
-                                                       el_speed, az_accl, el_accl])
+        self.assertListEqual(self.device.desiredPointing,
+                             np.asarray([_timestamp, az, el, az_speed,
+                                         el_speed, az_accl, el_accl], dtype=np.float32))
 
         # Change the values of the timestamp,  az and el
         _timestamp = time.time()
@@ -681,5 +683,6 @@ class test_XmiStaticAttributes(ClassCleanupUnittestMixin, unittest.TestCase):
             _timestamp, az, el, az_speed, el_speed, az_accl, el_accl
         ]
 
-        self.assertListEqual(self.device.desiredPointing[0], [_timestamp, az, el, az_speed,
-                                                       el_speed, az_accl, el_accl])
+        self.assertListEqual(self.device.desiredPointing,
+                             np.asarray([_timestamp, az, el, az_speed,
+                                         el_speed, az_accl, el_accl], dtype=np.float32))

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -288,6 +288,13 @@ class test_SimXmiDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase)
                 # its string returns 'READ' which corresponds to the Pogo one.
                 if attr_parameter in ['writable']:
                     attr_prop_value = str(attr_prop_value)
+                    if attr_prop_value == 'WT_UNKNOWN':  # Attributes with a 'READ_WRITE'
+                                                         # writable type are always set
+                                                         # to 'WT_UNKOWN', but the
+                                                         # `writable_attr_name` property
+                                                         # is set to the name of the
+                                                         # attribute.
+                        attr_prop_value = 'READ_WRITE'
 
                 if attr_prop_value is None:
                     # In the case where no attr_query data is not found it is

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -669,7 +669,7 @@ class test_XmiStaticAttributes(ClassCleanupUnittestMixin, unittest.TestCase):
         el_speed = 0.0
         az_accl = 0.0
         el_accl = 0.0
-        self.assertEqual(self.device.desiredPointing, [_timestamp, az, el, az_speed,
+        self.assertListEqual(self.device.desiredPointing, [_timestamp, az, el, az_speed,
                                                        el_speed, az_accl, el_accl])
 
         # Change the values of az and el
@@ -681,5 +681,5 @@ class test_XmiStaticAttributes(ClassCleanupUnittestMixin, unittest.TestCase):
             _timestamp, az, el, az_speed, el_speed, az_accl, el_accl
         ]
 
-        self.assertEqual(self.device.desiredPointing, [_timestamp, az, el, az_speed,
+        self.assertListEqual(self.device.desiredPointing, [_timestamp, az, el, az_speed,
                                                        el_speed, az_accl, el_accl])

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -669,10 +669,10 @@ class test_XmiStaticAttributes(ClassCleanupUnittestMixin, unittest.TestCase):
         el_speed = 0.0
         az_accl = 0.0
         el_accl = 0.0
-        self.assertListEqual(self.device.desiredPointing, [_timestamp, az, el, az_speed,
+        self.assertListEqual(self.device.desiredPointing[0], [_timestamp, az, el, az_speed,
                                                        el_speed, az_accl, el_accl])
 
-        # Change the values of az and el
+        # Change the values of the timestamp,  az and el
         _timestamp = time.time()
         az = 45.0
         el = 104.0
@@ -681,5 +681,5 @@ class test_XmiStaticAttributes(ClassCleanupUnittestMixin, unittest.TestCase):
             _timestamp, az, el, az_speed, el_speed, az_accl, el_accl
         ]
 
-        self.assertListEqual(self.device.desiredPointing, [_timestamp, az, el, az_speed,
+        self.assertListEqual(self.device.desiredPointing[0], [_timestamp, az, el, az_speed,
                                                        el_speed, az_accl, el_accl])

--- a/tango_simlib/tests/test_tango_sim_generator.py
+++ b/tango_simlib/tests/test_tango_sim_generator.py
@@ -283,3 +283,52 @@ class test_JsonFile(BaseTest.TangoSimGenDeviceIntegration):
         self.assertEquals(actual_device_cmds, set(expected_cmd_list),
                           "The commands specified in the json file are not present in"
                           " the device")
+
+
+class test_TangoSimGenerator(BaseTest.TangoSimGenDeviceIntegration):
+
+    @classmethod
+    def setUpClassWithCleanup(cls):
+        cls.server_name = 'DishElementMaster_ds'
+        cls.data_descr_file = 'devenum_test_case.xmi'
+        super(test_TangoSimGenerator, cls).setUpClassWithCleanup()
+
+    def setUp(self):
+        self.sim_file_parser = sim_xmi_parser.XmiParser()
+        super(test_TangoSimGenerator, self).setUp()
+
+    def test_device_init_command(self):
+        """Test that the TANGO device Init command works correctly."""
+        _timestamp = 0.0
+        az = 0.0
+        el = 0.0
+        az_speed = 0.0
+        el_speed = 0.0
+        az_accl = 0.0
+        el_accl = 0.0
+        self.assertListEqual(self.sim_device.desiredPointing.tolist(),
+                             [_timestamp, az, el, az_speed,
+                              el_speed, az_accl, el_accl])
+
+        # Change the values of the timestamp, az and el
+        _timestamp = 124324
+        az = 45.0
+        el = 104.0
+        # Write to the attribute desiredPointing
+        self.sim_device.desiredPointing = [
+            _timestamp, az, el, az_speed, el_speed, az_accl, el_accl
+        ]
+
+        self.assertListEqual(self.sim_device.desiredPointing.tolist(),
+                             [_timestamp, az, el, az_speed,
+                              el_speed, az_accl, el_accl])
+
+        # Reset the values of the device attributes to default.
+        self.sim_device.Init()
+        _timestamp = 0.0
+        az = 0.0
+        el = 0.0
+        # Check that the desiredPointing attribute is reset.
+        self.assertListEqual(self.sim_device.desiredPointing.tolist(),
+                             [_timestamp, az, el, az_speed,
+                              el_speed, az_accl, el_accl])

--- a/tango_simlib/tests/test_tango_sim_generator.py
+++ b/tango_simlib/tests/test_tango_sim_generator.py
@@ -289,8 +289,8 @@ class test_TangoSimGenerator(BaseTest.TangoSimGenDeviceIntegration):
 
     @classmethod
     def setUpClassWithCleanup(cls):
-        cls.server_name = 'DishElementMaster_ds'
-        cls.data_descr_file = 'devenum_test_case.xmi'
+        cls.server_name = 'weather_ds'
+        cls.data_descr_file = 'Weather.xmi'
         super(test_TangoSimGenerator, cls).setUpClassWithCleanup()
 
     def setUp(self):
@@ -299,36 +299,12 @@ class test_TangoSimGenerator(BaseTest.TangoSimGenDeviceIntegration):
 
     def test_device_init_command(self):
         """Test that the TANGO device Init command works correctly."""
-        _timestamp = 0.0
-        az = 0.0
-        el = 0.0
-        az_speed = 0.0
-        el_speed = 0.0
-        az_accl = 0.0
-        el_accl = 0.0
-        self.assertListEqual(self.sim_device.desiredPointing.tolist(),
-                             [_timestamp, az, el, az_speed,
-                              el_speed, az_accl, el_accl])
-
-        # Change the values of the timestamp, az and el
-        _timestamp = 124324
-        az = 45.0
-        el = 104.0
+        default_val = 0
+        self.assertEqual(self.sim_device.integer1, default_val)
         # Write to the attribute desiredPointing
-        self.sim_device.desiredPointing = [
-            _timestamp, az, el, az_speed, el_speed, az_accl, el_accl
-        ]
-
-        self.assertListEqual(self.sim_device.desiredPointing.tolist(),
-                             [_timestamp, az, el, az_speed,
-                              el_speed, az_accl, el_accl])
-
+        self.sim_device.integer1 = 45
+        self.assertEqual(self.sim_device.integer1, 45)
         # Reset the values of the device attributes to default.
         self.sim_device.Init()
-        _timestamp = 0.0
-        az = 0.0
-        el = 0.0
         # Check that the desiredPointing attribute is reset.
-        self.assertListEqual(self.sim_device.desiredPointing.tolist(),
-                             [_timestamp, az, el, az_speed,
-                              el_speed, az_accl, el_accl])
+        self.assertEqual(self.sim_device.integer1, default_val)


### PR DESCRIPTION
When writing to a _SPECTRUM_ type attribute, the data structure passed on to the write method is converted into an _numpy ndarray_ which was not handled. This was causing an error when it was trying to type cast an `numpy.ndarray` into an `int`.

The other issue is that the simulated quantity values were not being correctly reset to the default values. 
`simulated_quantity.attr = adjustable_val` was creating a new quantity attribute, `attr`, instead of assigning the value to the existing quantity attributes e.g. `(last_val, mean, std_dev, max_slew_rate, min_bound, max_bound)`.

This fixes the unit tests in [katproxy/pull/539](https://github.com/ska-sa/katproxy/pull/539)

*Definition of Done Checklist*

- [x] Code meets our [python style guidelines](https://docs.google.com/document/d/1aZoIyR9tz5rCWr2qJKuMTmKp2IzHlFjrCFrpDDHFypM/edit?usp=sharing)?
- [x] Unit tested (coded, passed, included)?
- [x] Requested at least 2 reviewers?
- [x] Commented code, particularly in hard-to-understand areas?
- [x] Made corresponding changes to the documentation (e.g. Python documentation, System Engineering Documentation, version description updates, README file, etc)?

JIRA: [MT-38](https://skaafrica.atlassian.net/browse/MT-38)
