### PR TITLE
Reducing the unnecessary logging of the TANGO device.

### DIFF
--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -60,7 +60,6 @@ class TangoDeviceServerBase(Device):
             name = attr.get_name()
             value, update_time = self.model.quantity_state[name]
             quality = AttrQuality.ATTR_VALID
-            self.debug_stream("Reading attribute %s", name)
             attr.set_value_date_quality(value, update_time, quality)
 
     def write_attributes(self, attr):
@@ -75,7 +74,6 @@ class TangoDeviceServerBase(Device):
         if self.get_state() != DevState.OFF:
             name = attr.get_name()
             data = attr.get_write_value()
-            self.debug_stream("Writing attribute {} with value: {}".format(name, data))
             self.model.sim_quantities[name].set_val(data, self.model.time_func())
 
 
@@ -144,7 +142,6 @@ def get_tango_device_server(model, sim_data_files):
             name = attr.get_name()
             value, update_time = tango_device_instance.model.quantity_state[name]
             quality = AttrQuality.ATTR_VALID
-            tango_device_instance.info_stream("Reading attribute %s", name)
             # For attributes that have a SPECTRUM data format, there is no need to
             # type cast them to an integer data type. we need assign the list of values
             # to the attribute value parameter.


### PR DESCRIPTION
This is a minor change to reduce the unnecessary logging that occurs when an attribute is read/written.

*Screenshots or code snippets (if appropriate):*

![screenshot from 2019-01-22 14-19-12](https://user-images.githubusercontent.com/16665803/51535336-d322c900-1e50-11e9-9ed0-3b623021354d.png)
Figure 1. This is a snapshot of the console output when we run the unit test, which is too noisy.

*Definition of Done Checklist*

- [x] Code meets our [python style guidelines](https://docs.google.com/document/d/1aZoIyR9tz5rCWr2qJKuMTmKp2IzHlFjrCFrpDDHFypM/edit?usp=sharing)?
- [x] Unit tested (coded, passed, included)?
- [x] Requested at least 2 reviewers?
- [x] Commented code, particularly in hard-to-understand areas?
- [x] Made corresponding changes to the documentation (e.g. Python documentation, System Engineering Documentation, version description updates, README file, etc)?

JIRA: [N/A]()
