### PR TITLE
Support multiple devices and control interfaces per server process

### DIFF
--- a/scripts/DishElementMaster-DS
+++ b/scripts/DishElementMaster-DS
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 from PyTango.server import server_run
-from tango_simlib.tango_sim_generator import (configure_device_model, get_tango_device_server)
+from tango_simlib.tango_sim_generator import (configure_device_models, get_tango_device_server)
 
 
-# File generated on Mon Oct 01 16:34:00 2018 by tango-simlib-generator
+# File generated on Tue Feb 12 15:21:00 2019 by tango-simlib-generator
 
 
 def main():
     sim_data_files = ['/home/kat/svn/tango-simlib/tango_simlib/tests/config_files/DishElementMaster.xmi', '/home/kat/svn/tango-simlib/tango_simlib/tests/config_files/DishElementMaster_SimDD.json']
-    model = configure_device_model(sim_data_files)
-    TangoDeviceServers = get_tango_device_server(model, sim_data_files)
+    models = configure_device_models(sim_data_files)
+    TangoDeviceServers = get_tango_device_server(models, sim_data_files)
     server_run(TangoDeviceServers)
 
 if __name__ == "__main__":

--- a/scripts/Weather-DS
+++ b/scripts/Weather-DS
@@ -1,15 +1,15 @@
 #!/usr/bin/env python
 from PyTango.server import server_run
-from tango_simlib.tango_sim_generator import (configure_device_model, get_tango_device_server)
+from tango_simlib.tango_sim_generator import (configure_device_models, get_tango_device_server)
 
 
-# File generated on Mon Oct 01 16:34:00 2018 by tango-simlib-tango-simulator-generator
+# File generated on Tue Feb 12 15:21:00 2019 by tango-simlib-tango-simulator-generator
 
 
 def main():
     sim_data_files = ['/home/kat/svn/tango-simlib/tango_simlib/tests/config_files/Weather.xmi', '/home/kat/svn/tango-simlib/tango_simlib/tests/config_files/Weather_SimDD.json']
-    model = configure_device_model(sim_data_files)
-    TangoDeviceServers = get_tango_device_server(model, sim_data_files)
+    models = configure_device_models(sim_data_files)
+    TangoDeviceServers = get_tango_device_server(models, sim_data_files)
     server_run(TangoDeviceServers)
 
 if __name__ == "__main__":

--- a/tango_simlib/examples/mkat_vds.py
+++ b/tango_simlib/examples/mkat_vds.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 from PyTango.server import server_run
-from tango_simlib.tango_sim_generator import (configure_device_model, get_tango_device_server)
+from tango_simlib.tango_sim_generator import (configure_device_models, get_tango_device_server)
 
 
 def main():
     sim_data_files = ['../tests/config_files/MkatVds.xmi', '../tests/config_files/MkatVds_SimDD.json']
-    model = configure_device_model(sim_data_files)
+    model = configure_device_models(sim_data_files)
     TangoDeviceServers = get_tango_device_server(model, sim_data_files)
     server_run(TangoDeviceServers)
 

--- a/tango_simlib/examples/weather1.py
+++ b/tango_simlib/examples/weather1.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 from PyTango.server import server_run
-from tango_simlib.tango_sim_generator import (configure_device_model, get_tango_device_server)
+from tango_simlib.tango_sim_generator import (configure_device_models, get_tango_device_server)
 
 
 def main():
     sim_data_files = ['../tests/config_files/Weather.xmi']
-    model = configure_device_model(sim_data_files)
+    model = configure_device_models(sim_data_files)
     TangoDeviceServers = get_tango_device_server(model, sim_data_files)
     server_run(TangoDeviceServers)
 

--- a/tango_simlib/examples/weather2.py
+++ b/tango_simlib/examples/weather2.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 from PyTango.server import server_run
-from tango_simlib.tango_sim_generator import (configure_device_model, get_tango_device_server)
+from tango_simlib.tango_sim_generator import (configure_device_models, get_tango_device_server)
 
 
 def main():
     sim_data_files = ['../tests/config_files/Weather_SimDD.json']
-    model = configure_device_model(sim_data_files)
+    model = configure_device_models(sim_data_files)
     TangoDeviceServers = get_tango_device_server(model, sim_data_files)
     server_run(TangoDeviceServers)
 

--- a/tango_simlib/examples/weather3.py
+++ b/tango_simlib/examples/weather3.py
@@ -1,11 +1,11 @@
 #!/usr/bin/env python
 from PyTango.server import server_run
-from tango_simlib.tango_sim_generator import (configure_device_model, get_tango_device_server)
+from tango_simlib.tango_sim_generator import (configure_device_models, get_tango_device_server)
 
 
 def main():
     sim_data_files = ['../tests/config_files/Weather.xmi', '../tests/config_files/Weather_SimDD_3.json']
-    model = configure_device_model(sim_data_files)
+    model = configure_device_models(sim_data_files)
     TangoDeviceServers = get_tango_device_server(model, sim_data_files)
     server_run(TangoDeviceServers)
 

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -463,10 +463,12 @@ def get_parser_instance(sim_datafile):
 def configure_device_model(sim_data_file=None, test_device_name=None):
     models = configure_device_models(sim_data_file, test_device_name)
     if len(models) == 1:
-        return models.values()[0]
+        return models
     else:
-        raise RuntimeError('Single model expected, but found {} models in {}'
-                           .format(len(models), sim_data_file))
+        raise RuntimeError('Single model expected, but found {} devices {}'
+                           ' registered under device server class {}. Rather use '
+                           ' `configure_device_models`.'
+                           .format(len(models), get_device_class(sim_data_file)))
 
 def configure_device_models(sim_data_file=None, test_device_name=None):
     """In essence this function should get the data descriptor file, parse it,

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -170,7 +170,8 @@ def get_tango_device_server(models, sim_data_files):
         MODULE_LOGGER.info("Adding static attribute {} to the device.".format(attr_name))
 
     # Sim test interface static attribute `attribute_name` info
-    controllable_attribute_names = model.sim_quantities.keys()
+    # Pick the first model instance in the dict.
+    controllable_attribute_names = models.values()[0].sim_quantities.keys()
     attr_control_meta = dict()
     attr_control_meta['enum_labels'] = sorted(controllable_attribute_names)
     attr_control_meta['data_format'] = AttrDataFormat.SCALAR
@@ -202,7 +203,7 @@ def get_tango_device_server(models, sim_data_files):
     # TODO(AR 02-03-2017): Ask the tango community on the upcoming Stack
     # Exchange community (AskTango) and also make follow ups on the next tango
     # releases.
-    for quantity_name, quantity in model.sim_quantities.items():
+    for quantity_name, quantity in models.values()[0].sim_quantities.items():
         d_type = quantity.meta['data_type']
         d_type = str(quantity.meta['data_type'])
         d_format = str(quantity.meta['data_format'])

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -533,7 +533,7 @@ def generate_device_server(server_name, sim_data_files, directory=''):
     """Create a tango device server python file
 
     Parameters
-    ---------
+    ----------
     server_name: str
         Tango device server name
     sim_data_files: list

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -216,10 +216,12 @@ def get_tango_device_server(models, sim_data_files):
     class TangoDeviceServer(TangoDeviceServerBase, TangoDeviceServerStaticAttrs):
         __metaclass__ = DeviceMeta
         _models = models
+        print _models
 
         def init_device(self):
             super(TangoDeviceServer, self).init_device()
             self.model = self._models[self.get_name()]
+            print self.model
             self._not_added_attributes = []
             write_device_properties_to_db(self.get_name(), self.model)
             self._reset_to_default_state()
@@ -466,7 +468,7 @@ def configure_device_model(sim_data_file=None, test_device_name=None):
     if len(models) == 1:
         return models
     else:
-        raise RuntimeError('Single model expected, but found {} devices {}'
+        raise RuntimeError('Single model expected, but found {} devices'
                            ' registered under device server class {}. Rather use '
                            ' `configure_device_models`.'
                            .format(len(models), get_device_class(sim_data_file)))

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -216,12 +216,10 @@ def get_tango_device_server(models, sim_data_files):
     class TangoDeviceServer(TangoDeviceServerBase, TangoDeviceServerStaticAttrs):
         __metaclass__ = DeviceMeta
         _models = models
-        print _models
 
         def init_device(self):
             super(TangoDeviceServer, self).init_device()
             self.model = self._models[self.get_name()]
-            print self.model
             self._not_added_attributes = []
             write_device_properties_to_db(self.get_name(), self.model)
             self._reset_to_default_state()

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -484,7 +484,7 @@ def configure_device_models(sim_data_file=None, test_device_name=None):
     """
     data_file = sim_data_file
     klass_name = get_device_class(data_file)
-
+    dev_names = None
     if test_device_name is None:
         server_name = helper_module.get_server_name()
         db_instance = helper_module.get_database()

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -214,15 +214,11 @@ def get_tango_device_server(models, sim_data_files):
 
     class TangoDeviceServer(TangoDeviceServerBase, TangoDeviceServerStaticAttrs):
         __metaclass__ = DeviceMeta
-        models = models
-
-        def __init__(self, dev_class, name):
-            super(TangoDeviceServer, self).__init__(dev_class, name)
-            self.init_device()
+        _models = models
 
         def init_device(self):
             super(TangoDeviceServer, self).init_device()
-            self.model = self.models[self.get_name()]
+            self.model = self._models[self.get_name()]
             self._not_added_attributes = []
             write_device_properties_to_db(self.get_name(), self.model)
             self._reset_to_default_state()

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -222,7 +222,7 @@ def get_tango_device_server(models, sim_data_files):
 
         def init_device(self):
             super(TangoDeviceServer, self).init_device()
-            self.model = models[self.get_name()]
+            self.model = self.models[self.get_name()]
             self._not_added_attributes = []
             write_device_properties_to_db(self.get_name(), self.model)
             self._reset_to_default_state()

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -461,7 +461,12 @@ def get_parser_instance(sim_datafile):
     return parser_instance
 
 def configure_device_model(sim_data_file=None, test_device_name=None):
-    return configure_device_models(sim_data_file, test_device_name)
+    models = configure_device_models(sim_data_file, test_device_name)
+    if len(models) == 1:
+        return models.values()[0]
+    else:
+        raise RuntimeError('Single model expected, but found {} models in {}'
+                           .format(len(models), sim_data_file))
 
 def configure_device_models(sim_data_file=None, test_device_name=None):
     """In essence this function should get the data descriptor file, parse it,

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -518,12 +518,12 @@ def configure_device_models(sim_data_file=None, test_device_name=None):
         properties_info = {}
         override_info = {}
         for parser in parsers:
-            PopulateModelQuantities(parser, dev_name, model)
+            PopulateModelQuantities(parser, model.name, model)
             command_info.update(parser.get_device_command_metadata())
             properties_info.update(parser.get_device_properties_metadata('deviceProperties'))
             override_info.update(parser.get_device_cmd_override_metadata())
-        PopulateModelActions(command_info, override_info, dev_name, model)
-        PopulateModelProperties(properties_info, dev_name, model)
+        PopulateModelActions(command_info, override_info, model.name, model)
+        PopulateModelProperties(properties_info, model.name, model)
     return models
 
 def generate_device_server(server_name, sim_data_files, directory=''):

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -467,7 +467,7 @@ def configure_device_model(sim_data_file=None, test_device_name=None):
         return models
     else:
         raise RuntimeError('Single model expected, but found {} devices'
-                           ' registered under device server class {}. Rather use '
+                           ' registered under device server class {}. Rather use'
                            ' `configure_device_models`.'
                            .format(len(models), get_device_class(sim_data_file)))
 

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -460,6 +460,9 @@ def get_parser_instance(sim_datafile):
         parser_instance.parse(sim_datafile)
     return parser_instance
 
+def configure_device_model(sim_data_file=None, test_device_name=None):
+    return configure_device_models(sim_data_file, test_device_name)
+
 def configure_device_models(sim_data_file=None, test_device_name=None):
     """In essence this function should get the data descriptor file, parse it,
     take the attribute and command information, populate the model quantities and
@@ -476,7 +479,7 @@ def configure_device_models(sim_data_file=None, test_device_name=None):
     Returns
     -------
     models : dict
-        A dictionary of model.Model instance
+        A dictionary of model.Model instances
 
     """
     data_file = sim_data_file

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -84,8 +84,9 @@ def get_tango_device_server(models, sim_data_files):
 
     Parameters
     ----------
-    model: model.Model instance dict
-        Device model instance
+    models: dict
+        A dictionary of model.Model instances.
+        e.g. {'model-name': model.Model}
     sim_data_files: list
         A list of direct paths to either xmi/xml/json data files.
 
@@ -472,7 +473,7 @@ def configure_device_model(sim_data_file=None, test_device_name=None):
 
 def configure_device_models(sim_data_file=None, test_device_name=None):
     """In essence this function should get the data descriptor file, parse it,
-    take the attribute and command information, populate the model quantities and
+    take the attribute and command information, populate the model(s) quantities and
     actions to be simulated and return that model.
 
     Parameters

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -214,10 +214,10 @@ def get_tango_device_server(models, sim_data_files):
 
     class TangoDeviceServer(TangoDeviceServerBase, TangoDeviceServerStaticAttrs):
         __metaclass__ = DeviceMeta
+        models = models
 
         def __init__(self, dev_class, name):
             super(TangoDeviceServer, self).__init__(dev_class, name)
-            self.models = models
             self.init_device()
 
         def init_device(self):

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -78,13 +78,13 @@ class TangoDeviceServerBase(Device):
             self.model.sim_quantities[name].set_val(data, self.model.time_func())
 
 
-def get_tango_device_server(model, sim_data_files):
+def get_tango_device_server(models, sim_data_files):
     """Declares a tango device class that inherits the Device class and then
     adds tango attributes (DevEnum and Spectrum type).
 
     Parameters
     ----------
-    model: model.Model instance
+    model: model.Model instance dict
         Device model instance
     sim_data_files: list
         A list of direct paths to either xmi/xml/json data files.
@@ -214,9 +214,14 @@ def get_tango_device_server(model, sim_data_files):
     class TangoDeviceServer(TangoDeviceServerBase, TangoDeviceServerStaticAttrs):
         __metaclass__ = DeviceMeta
 
+        def __init__(self, dev_class, name):
+            super(TangoDeviceServer, self).__init__(dev_class, name)
+            self.models = models
+            self.init_device()
+
         def init_device(self):
             super(TangoDeviceServer, self).init_device()
-            self.model = model
+            self.model = models[self.get_name()]
             self._not_added_attributes = []
             write_device_properties_to_db(self.get_name(), self.model)
             self._reset_to_default_state()
@@ -458,7 +463,7 @@ def get_parser_instance(sim_datafile):
         parser_instance.parse(sim_datafile)
     return parser_instance
 
-def configure_device_model(sim_data_file=None, test_device_name=None):
+def configure_device_models(sim_data_file=None, test_device_name=None):
     """In essence this function should get the data descriptor file, parse it,
     take the attribute and command information, populate the model quantities and
     actions to be simulated and return that model.
@@ -473,7 +478,8 @@ def configure_device_model(sim_data_file=None, test_device_name=None):
 
     Returns
     -------
-    model : model.Model instance
+    models : dict
+        A dictionary of model.Model instance
 
     """
     data_file = sim_data_file
@@ -490,11 +496,7 @@ def configure_device_model(sim_data_file=None, test_device_name=None):
         # We assume that at least one device instance has been
         # registered for that class and device server.
         dev_names = getattr(db_datum, 'value_string')
-        if dev_names:
-            dev_name = dev_names[0]
-        else:
-            # In case a device name is not provided during testing a
-            # default name is assigned since it cannot be found in database.
+        if not dev_names:
             dev_name = 'test/nodb/tangodeviceserver'
     else:
         dev_name = test_device_name
@@ -505,20 +507,27 @@ def configure_device_model(sim_data_file=None, test_device_name=None):
     for file_name in data_file:
         parsers.append(get_parser_instance(file_name))
 
+    # In case there is more than one device instance per class.
+    models = {}
+    if dev_names:
+        for dev_name in dev_names:
+            models[dev_name] = Model(dev_name)
+    else:
+        models[dev_name] = Model(dev_name)
+
     # In case there is more than one parser instance for each file
-    model = Model(dev_name)
-    command_info = {}
-    properties_info = {}
-    override_info = {}
-    for parser in parsers:
-        PopulateModelQuantities(parser, dev_name, model)
-        command_info.update(parser.get_device_command_metadata())
-        properties_info.update(parser.get_device_properties_metadata('deviceProperties'))
-        override_info.update(parser.get_device_cmd_override_metadata())
-    PopulateModelActions(command_info, override_info, dev_name, model)
-    PopulateModelProperties(properties_info, dev_name, model)
-    
-    return model
+    for model in models.values():
+        command_info = {}
+        properties_info = {}
+        override_info = {}
+        for parser in parsers:
+            PopulateModelQuantities(parser, dev_name, model)
+            command_info.update(parser.get_device_command_metadata())
+            properties_info.update(parser.get_device_properties_metadata('deviceProperties'))
+            override_info.update(parser.get_device_cmd_override_metadata())
+        PopulateModelActions(command_info, override_info, dev_name, model)
+        PopulateModelProperties(properties_info, dev_name, model)
+    return models
 
 def generate_device_server(server_name, sim_data_files, directory=''):
     """Create a tango device server python file
@@ -534,12 +543,12 @@ def generate_device_server(server_name, sim_data_files, directory=''):
     lines = ['#!/usr/bin/env python',
              'from tango.server import server_run',
              ('from tango_simlib.tango_sim_generator import ('
-              'configure_device_model, get_tango_device_server)'),
+              'configure_device_models, get_tango_device_server)'),
              '\n\n# File generated on {} by tango-simlib-generator'.format(time.ctime()),
              '\n\ndef main():',
              '    sim_data_files = %s' % sim_data_files,
-             '    model = configure_device_model(sim_data_files)',
-             '    TangoDeviceServers = get_tango_device_server(model, sim_data_files)',
+             '    models = configure_device_models(sim_data_files)',
+             '    TangoDeviceServers = get_tango_device_server(models, sim_data_files)',
              '    server_run(TangoDeviceServers)',
              '\nif __name__ == "__main__":',
              '    main()\n']
@@ -589,8 +598,8 @@ def get_device_class(sim_data_files):
 
 def get_argparser():
     parser = argparse.ArgumentParser(
-            description="Generate a tango data driven simulator, handling"
-            "registration as needed. Supports multiple device per process.")
+        description="Generate a tango data driven simulator, handling"
+        " registration as needed. Supports multiple device per process.")
     required_argument = partial(parser.add_argument, required=True)
     required_argument('--sim-data-file', action='append',
                       help='Simulator description data files(s) '

--- a/tango_simlib/tests/config_files/multidevice.xmi
+++ b/tango_simlib/tests/config_files/multidevice.xmi
@@ -1,0 +1,18 @@
+<?xml version="1.0" encoding="ASCII"?>
+<pogoDsl:PogoSystem xmi:version="2.0" xmlns:xmi="http://www.omg.org/XMI" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xmlns:pogoDsl="http://www.esrf.fr/tango/pogo/PogoDsl">
+  <classes name="MultiDeviceModel" pogoRevision="9.1">
+    <description description="The DSH shall provide a self-description on request from the TM" sourcePath="/home/athanaseus/Desktop/Projects/FEB/Sprint28/LMC/Element" language="Python" filestogenerate="XMI   file,Code files,Protected Regions,html Pages" license="GPL" copyright="" hasMandatoryProperty="false" hasConcreteProperty="true" hasAbstractCommand="false" hasAbstractAttribute="false" descriptionHtmlExists="false">
+      <inheritances classname="Device_Impl" sourcePath=""/>
+      <identification contact="at ska.ac.za - aramaila" author="aramaila" emailDomain="ska.ac.za" classFamily="Simulators" siteSpecific="" platform="Unix Like" bus="TCP/UDP" manufacturer="none" reference=""/>
+    </description>
+    <attributes name="models" attType="Scalar" rwType="READ" displayLevel="OPERATOR" polledPeriod="1000" maxX="" maxY="" allocReadMember="false" isDynamic="false">
+      <dataType xsi:type="pogoDsl:UIntType"/>
+      <changeEvent fire="false" libCheckCriteria="false"/>
+      <archiveEvent fire="false" libCheckCriteria="false"/>
+      <dataReadyEvent fire="false" libCheckCriteria="true"/>
+      <status abstract="false" inherited="false" concrete="true" concreteHere="true"/>
+      <properties description="" label="number of models" unit="" standardUnit="" displayUnit="" format="" maxValue="" minValue="" maxAlarm="" minAlarm="" maxWarning="" minWarning="" deltaTime="" deltaValue=""/>
+    </attributes>
+    <preferences docHome="./doc_html" makefileHome="/usr/share/pogo/preferences"/>
+  </classes>
+</pogoDsl:PogoSystem>

--- a/tango_simlib/tests/config_files/multidevice_tango.db
+++ b/tango_simlib/tests/config_files/multidevice_tango.db
@@ -1,0 +1,42 @@
+#
+# Resource backup , created Tue Feb 19 12:07:13 GMT 2019
+#
+
+#---------------------------------------------------------
+# SERVER MultiDeviceModel/test, MultiDeviceModel device declaration
+#---------------------------------------------------------
+
+MultiDeviceModel/test/DEVICE/MultiDeviceModel: "test/nodb/tangodeviceserver1",\ 
+                                               "test/nodb/tangodeviceserver2",\ 
+                                               "test/nodb/tangodeviceserver3"
+
+
+#---------------------------------------------------------
+# CLASS MultiDeviceModel properties
+#---------------------------------------------------------
+
+
+#---------------------------------------------------------
+# SERVER MultiDeviceModel/test, MultiDeviceModelSimControl device declaration
+#---------------------------------------------------------
+
+MultiDeviceModel/test/DEVICE/MultiDeviceModelSimControl: "test/nodb/tangodeviceserversimcontrol1",\ 
+                                                         "test/nodb/tangodeviceserversimcontrol2",\ 
+                                                         "test/nodb/tangodeviceserversimcontrol3"
+
+
+# --- test/nodb/tangodeviceserversimcontrol1 properties
+
+test/nodb/tangodeviceserversimcontrol1->model_key: "test/nodb/tangodeviceserver1"
+
+# --- test/nodb/tangodeviceserversimcontrol2 properties
+
+test/nodb/tangodeviceserversimcontrol2->model_key: "test/nodb/tangodeviceserver2"
+
+# --- test/nodb/tangodeviceserversimcontrol3 properties
+
+test/nodb/tangodeviceserversimcontrol3->model_key: "test/nodb/tangodeviceserver3"
+
+#---------------------------------------------------------
+# CLASS MultiDeviceModelSimControl properties
+#---------------------------------------------------------

--- a/tango_simlib/tests/config_files/multidevice_tango.db
+++ b/tango_simlib/tests/config_files/multidevice_tango.db
@@ -1,42 +1,55 @@
-#
-# Resource backup , created Tue Feb 19 12:07:13 GMT 2019
-#
-
-#---------------------------------------------------------
-# SERVER MultiDeviceModel/test, MultiDeviceModel device declaration
-#---------------------------------------------------------
-
-MultiDeviceModel/test/DEVICE/MultiDeviceModel: "test/nodb/tangodeviceserver1",\ 
-                                               "test/nodb/tangodeviceserver2",\ 
+MultiDeviceModel/test/DEVICE/MultiDeviceModel: "test/nodb/tangodeviceserver1",\
+                                               "test/nodb/tangodeviceserver2",\
                                                "test/nodb/tangodeviceserver3"
-
-
-#---------------------------------------------------------
-# CLASS MultiDeviceModel properties
-#---------------------------------------------------------
-
-
-#---------------------------------------------------------
-# SERVER MultiDeviceModel/test, MultiDeviceModelSimControl device declaration
-#---------------------------------------------------------
-
-MultiDeviceModel/test/DEVICE/MultiDeviceModelSimControl: "test/nodb/tangodeviceserversimcontrol1",\ 
-                                                         "test/nodb/tangodeviceserversimcontrol2",\ 
+MultiDeviceModel/test/DEVICE/MultiDeviceModelSimControl: "test/nodb/tangodeviceserversimcontrol1",\
+                                                         "test/nodb/tangodeviceserversimcontrol2",\
                                                          "test/nodb/tangodeviceserversimcontrol3"
 
+#############################################
+# CLASS MultiDeviceModel
 
-# --- test/nodb/tangodeviceserversimcontrol1 properties
 
-test/nodb/tangodeviceserversimcontrol1->model_key: "test/nodb/tangodeviceserver1"
+# CLASS MultiDeviceModel attribute properties
 
-# --- test/nodb/tangodeviceserversimcontrol2 properties
 
-test/nodb/tangodeviceserversimcontrol2->model_key: "test/nodb/tangodeviceserver2"
+#############################################
+# CLASS MultiDeviceModelSimControl
 
-# --- test/nodb/tangodeviceserversimcontrol3 properties
 
-test/nodb/tangodeviceserversimcontrol3->model_key: "test/nodb/tangodeviceserver3"
+# CLASS MultiDeviceModelSimControl attribute properties
 
-#---------------------------------------------------------
-# CLASS MultiDeviceModelSimControl properties
-#---------------------------------------------------------
+
+
+# DEVICE test/nodb/tangodeviceserver1 properties 
+
+
+# DEVICE test/nodb/tangodeviceserver1 attribute properties
+
+# DEVICE test/nodb/tangodeviceserver2 properties 
+
+
+# DEVICE test/nodb/tangodeviceserver2 attribute properties
+
+# DEVICE test/nodb/tangodeviceserver3 properties 
+
+
+# DEVICE test/nodb/tangodeviceserver3 attribute properties
+
+# DEVICE test/nodb/tangodeviceserversimcontrol1 properties 
+
+test/nodb/tangodeviceserversimcontrol1->model_key: test/nodb/tangodeviceserver1
+
+# DEVICE test/nodb/tangodeviceserversimcontrol1 attribute properties
+
+# DEVICE test/nodb/tangodeviceserversimcontrol2 properties 
+
+test/nodb/tangodeviceserversimcontrol2->model_key: test/nodb/tangodeviceserver2
+
+# DEVICE test/nodb/tangodeviceserversimcontrol2 attribute properties
+
+# DEVICE test/nodb/tangodeviceserversimcontrol3 properties 
+
+test/nodb/tangodeviceserversimcontrol3->model_key: test/nodb/tangodeviceserver3
+
+# DEVICE test/nodb/tangodeviceserversimcontrol3 attribute properties
+

--- a/tango_simlib/tests/test_dish.py
+++ b/tango_simlib/tests/test_dish.py
@@ -53,8 +53,9 @@ class test_DishElementMaster(ClassCleanupUnittestMixin, unittest.TestCase):
         cls.data_descr_files.append(pkg_resources.resource_filename(
             'tango_simlib.tests.config_files', 'DishElementMaster_SimDD.json'))
         cls.device_name = 'test/nodb/tangodeviceserver'
-        cls.model = tango_sim_generator.configure_device_models(
+        cls.models = tango_sim_generator.configure_device_models(
             cls.data_descr_files, cls.device_name)
+        cls.model = cls.models.values()[0]
 
     def setUp(self):
         super(test_DishElementMaster, self).setUp()

--- a/tango_simlib/tests/test_dish.py
+++ b/tango_simlib/tests/test_dish.py
@@ -53,7 +53,7 @@ class test_DishElementMaster(ClassCleanupUnittestMixin, unittest.TestCase):
         cls.data_descr_files.append(pkg_resources.resource_filename(
             'tango_simlib.tests.config_files', 'DishElementMaster_SimDD.json'))
         cls.device_name = 'test/nodb/tangodeviceserver'
-        cls.model = tango_sim_generator.configure_device_model(
+        cls.model = tango_sim_generator.configure_device_models(
             cls.data_descr_files, cls.device_name)
 
     def setUp(self):
@@ -359,7 +359,7 @@ class test_Device(ClassCleanupUnittestMixin, unittest.TestCase):
         cls.data_descr_files.append(pkg_resources.resource_filename(
             'tango_simlib.tests.config_files', 'DishElementMaster_SimDD.json'))
         cls.device_name = 'test/nodb/tangodeviceserver'
-        model = tango_sim_generator.configure_device_model(cls.data_descr_files,
+        model = tango_sim_generator.configure_device_models(cls.data_descr_files,
                                                            cls.device_name)
         cls.TangoDeviceServer = tango_sim_generator.get_tango_device_server(
                 model, cls.data_descr_files)[0]

--- a/tango_simlib/tests/test_sim_test_interface.py
+++ b/tango_simlib/tests/test_sim_test_interface.py
@@ -100,12 +100,13 @@ class test_SimControl(unittest.TestCase):
     @classmethod
     def setUpClass(cls):
         cls.test_model = FixtureModel('the_test_model')
+        cls.models = {'the_test_model': cls.test_model}
         # The get_tango_device_server function requires  data file which it uses to
         # extract the device class name. However for this test we don't need  it,
         # hence the use of the dummy sim data file.
         cls.device_name = 'test/nodb/tangodeviceserver'
         cls.device_klass = tango_sim_generator.get_tango_device_server(
-            cls.test_model, ['dummy_sim_data_file.txt'])[-1]
+            cls.models, ['dummy_sim_data_file.txt'])[-1]
         cls.tango_context = DeviceTestContext(cls.device_klass,
                                               device_name=cls.device_name,
                                               properties=cls.properties)

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -220,7 +220,7 @@ class test_SimXmiDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase)
         cls.xmi_file = [pkg_resources.resource_filename(
             'tango_simlib.tests.config_files', 'Weather.xmi')]
         cls.device_name = 'test/nodb/tangodeviceserver'
-        model = tango_sim_generator.configure_device_model(cls.xmi_file,
+        model = tango_sim_generator.configure_device_models(cls.xmi_file,
                                                            cls.device_name)
         cls.TangoDeviceServer = tango_sim_generator.get_tango_device_server(
             model, cls.xmi_file)[0]
@@ -578,7 +578,7 @@ class test_XmiStaticAttributes(ClassCleanupUnittestMixin, unittest.TestCase):
         cls.xmi_file = [pkg_resources.resource_filename(
             'tango_simlib.tests.config_files', 'devenum_test_case.xmi')]
         cls.device_name = 'test/nodb/tangodeviceserver'
-        model = tango_sim_generator.configure_device_model(cls.xmi_file,
+        model = tango_sim_generator.configure_device_models(cls.xmi_file,
                                                            cls.device_name)
         cls.TangoDeviceServer = tango_sim_generator.get_tango_device_server(
             model, cls.xmi_file)[0]

--- a/tango_simlib/tests/test_simdd_json_parser.py
+++ b/tango_simlib/tests/test_simdd_json_parser.py
@@ -276,7 +276,7 @@ class test_SimddDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase):
         cls.data_descr_file = [pkg_resources.resource_filename(
             'tango_simlib.tests.config_files', 'Weather_SimDD.json')]
         cls.device_name = 'test/nodb/tangodeviceserver'
-        model = tango_sim_generator.configure_device_model(cls.data_descr_file,
+        model = tango_sim_generator.configure_device_models(cls.data_descr_file,
                                                            cls.device_name)
         cls.TangoDeviceServer = tango_sim_generator.get_tango_device_server(
                     model, cls.data_descr_file)[0]
@@ -443,7 +443,7 @@ class test_XmiSimddDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCas
         cls.data_descr_files.append(pkg_resources.resource_filename(
             'tango_simlib.tests.config_files', 'MkatVds_SimDD.json'))
         cls.device_name = 'test/nodb/tangodeviceserver'
-        model = tango_sim_generator.configure_device_model(
+        model = tango_sim_generator.configure_device_models(
             cls.data_descr_files, cls.device_name)
         cls.TangoDeviceServer = tango_sim_generator.get_tango_device_server(
             model, cls.data_descr_files)[0]
@@ -604,7 +604,7 @@ class test_XmiSimddSupplementaryDeviceIntegration(ClassCleanupUnittestMixin,
         cls.data_descr_files.append(pkg_resources.resource_filename(
             'tango_simlib.tests.config_files', 'Weather_SimDD_2.json'))
         cls.device_name = 'test/nodb/tangodeviceserver'
-        model = tango_sim_generator.configure_device_model(
+        model = tango_sim_generator.configure_device_models(
             cls.data_descr_files, cls.device_name)
         cls.TangoDeviceServer = tango_sim_generator.get_tango_device_server(
             model, cls.data_descr_files)[0]

--- a/tango_simlib/tests/test_tango_sim_generator.py
+++ b/tango_simlib/tests/test_tango_sim_generator.py
@@ -81,7 +81,7 @@ class BaseTest(object):
         def setUp(self):
             super(BaseTest.TangoSimGenDeviceIntegration, self).setUp()
             self.sim_file_parser.parse(self.data_descr_file[0])
-            self.expected_model = tango_sim_generator.configure_device_models(
+            self.expected_models = tango_sim_generator.configure_device_models(
                 self.data_descr_file, self.sim_device.name())
             self.attr_name_enum_labels = sorted(
                 self.sim_control_device.attribute_query(

--- a/tango_simlib/tests/test_tango_sim_generator.py
+++ b/tango_simlib/tests/test_tango_sim_generator.py
@@ -318,6 +318,7 @@ class test_TangoSimGenerator2(ClassCleanupUnittestMixin, unittest.TestCase):
 
     longMessage = True
     server_name = 'MultiDeviceModel/test'
+    num_of_registered_devices = 3
 
     @classmethod
     def setUpClass(cls):
@@ -338,7 +339,7 @@ class test_MultiModel(test_TangoSimGenerator2):
     def test_configure_models(self):
         models = tango_sim_generator.configure_device_models(
             self.data_descr_files)
-        self.assertGreater(len(models.keys()), 1)
+        self.assertEqual(len(models.keys()), self.num_of_registered_devices)
 
     def test_configure_model(self):
         with self.assertRaises(RuntimeError) as cm:

--- a/tango_simlib/tests/test_tango_sim_generator.py
+++ b/tango_simlib/tests/test_tango_sim_generator.py
@@ -81,7 +81,7 @@ class BaseTest(object):
         def setUp(self):
             super(BaseTest.TangoSimGenDeviceIntegration, self).setUp()
             self.sim_file_parser.parse(self.data_descr_file[0])
-            self.expected_model = tango_sim_generator.configure_device_model(
+            self.expected_model = tango_sim_generator.configure_device_models(
                 self.data_descr_file, self.sim_device.name())
             self.attr_name_enum_labels = sorted(
                 self.sim_control_device.attribute_query(

--- a/tango_simlib/tests/test_tango_sim_generator.py
+++ b/tango_simlib/tests/test_tango_sim_generator.py
@@ -83,6 +83,7 @@ class BaseTest(object):
             self.sim_file_parser.parse(self.data_descr_file[0])
             self.expected_models = tango_sim_generator.configure_device_models(
                 self.data_descr_file, self.sim_device.name())
+            self.expected_model = self.expected_models.values()[0]
             self.attr_name_enum_labels = sorted(
                 self.sim_control_device.attribute_query(
                     'attribute_name').enum_labels)


### PR DESCRIPTION
This was an raised in issue #56 where a user wanted to have multiple devices and corresponding sim control interfaces in one device server process.

The root cause was that we were only creating one model instance for the first registered device in the database, resulting in the error described in the issue.

This PR solves that in that we **create a model for each registered device** that will be used for simulation.

*Screenshots or code snippets (if appropriate):*

![tango-simlib - multi model generation pptx](https://user-images.githubusercontent.com/16665803/53246865-83872580-36ba-11e9-922f-af2670f5dcde.jpg)
**Figure 1**. This shows the single model instance shared between multiple devices causing the error in the other sim control device.

![tango-simlib - multi model generation pptx 1](https://user-images.githubusercontent.com/16665803/53246872-871aac80-36ba-11e9-8fb4-10860aaff771.jpg)
**Figure 2**. A snapshot of the new design, creating a model instance per device/sim control pair.

*Definition of Done Checklist*

- [x] Code meets our [python style guidelines](https://docs.google.com/document/d/1aZoIyR9tz5rCWr2qJKuMTmKp2IzHlFjrCFrpDDHFypM/edit?usp=sharing)?
- [x] Unit tested (coded, passed, included)?
- [x] Requested at least 2 reviewers?
- [x] Commented code, particularly in hard-to-understand areas?
- [x] Made corresponding changes to the documentation (e.g. Python documentation, System Engineering Documentation, version description updates, README file, etc)?

JIRA: [MT-465](https://skaafrica.atlassian.net/browse/MT-465), [LMC-341](https://skaafrica.atlassian.net/browse/LMC-341)
