### PR TITLE
pin numpy to versions with py2 support < 1.17

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,11 @@ setup(name="tango_simlib",
       use_katversion=True,
       install_requires=[
           "PyTango>=9.2.2",
-          "numpy",
+          "numpy<1.17",
           "jsonschema"],
       tests_require=[
           'katcp',
-          'numpy',
+          'numpy<1.17',
           'nose_xunitmp'],
       extras_require={
           'docs': ["sphinx-pypi-upload",

--- a/setup.py
+++ b/setup.py
@@ -22,11 +22,11 @@ setup(name="tango_simlib",
       use_katversion=True,
       install_requires=[
           "PyTango>=9.2.2",
-          "numpy<1.17",
+          "numpy>=1.17" if sys.version_info >= (3, 5) else "numpy<1.17",
           "jsonschema"],
       tests_require=[
           'katcp',
-          'numpy<1.17',
+          'numpy>=1.17' if sys.version_info >= (3, 5) else 'numpy<1.17',
           'nose_xunitmp'],
       extras_require={
           'docs': ["sphinx-pypi-upload",

--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,6 @@
 #!/usr/bin/env python
 
+import sys
 from setuptools import setup, find_packages
 
 setup(name="tango_simlib",


### PR DESCRIPTION
Numpy's 1.17 pre-release has dropped support to python 2. See numpy [repo](https://github.com/numpy/numpy/releases/tag/v1.17.0rc1).

This PR is to ensure that the numpy install < v1.17