### PR TITLE
Stage 1 Futurize [Python 2 to Python 3 Migration]

### DIFF
--- a/doc/conf.py
+++ b/doc/conf.py
@@ -16,6 +16,9 @@
 # add these directories to sys.path here. If the directory is relative to the
 # documentation root, use os.path.abspath to make it absolute, like shown here.
 #
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import os
 import sys
 import mock

--- a/scripts/DishElementMaster-DS
+++ b/scripts/DishElementMaster-DS
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from PyTango.server import server_run
 from tango_simlib.tango_sim_generator import (configure_device_models, get_tango_device_server)
 

--- a/scripts/Weather-DS
+++ b/scripts/Weather-DS
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from PyTango.server import server_run
 from tango_simlib.tango_sim_generator import (configure_device_models, get_tango_device_server)
 

--- a/setup.py
+++ b/setup.py
@@ -23,7 +23,9 @@ setup(name="tango_simlib",
       install_requires=[
           "PyTango>=9.2.2",
           "numpy",
-          "jsonschema"],
+          "jsonschema",
+          "future",
+          "futures; python_version<'3'"],
       tests_require=[
           'katcp',
           'numpy',

--- a/tango_simlib/__init__.py
+++ b/tango_simlib/__init__.py
@@ -2,6 +2,9 @@
 
 # BEGIN VERSION CHECK
 # Get package version when locally imported from repo or via -e develop install
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 try:
     import katversion as _katversion
 except ImportError:

--- a/tango_simlib/examples/mkat_vds.py
+++ b/tango_simlib/examples/mkat_vds.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from PyTango.server import server_run
 from tango_simlib.tango_sim_generator import (configure_device_models, get_tango_device_server)
 

--- a/tango_simlib/examples/override_class.py
+++ b/tango_simlib/examples/override_class.py
@@ -6,6 +6,9 @@
 """
 An example of the user-defined override class.
 """
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 import logging
 

--- a/tango_simlib/examples/weather1.py
+++ b/tango_simlib/examples/weather1.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from PyTango.server import server_run
 from tango_simlib.tango_sim_generator import (configure_device_models, get_tango_device_server)
 

--- a/tango_simlib/examples/weather2.py
+++ b/tango_simlib/examples/weather2.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from PyTango.server import server_run
 from tango_simlib.tango_sim_generator import (configure_device_models, get_tango_device_server)
 

--- a/tango_simlib/examples/weather3.py
+++ b/tango_simlib/examples/weather3.py
@@ -1,4 +1,7 @@
 #!/usr/bin/env python
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 from PyTango.server import server_run
 from tango_simlib.tango_sim_generator import (configure_device_models, get_tango_device_server)
 

--- a/tango_simlib/main.py
+++ b/tango_simlib/main.py
@@ -4,6 +4,9 @@
 #                                                                                       #
 # BSD license - see LICENSE.txt for details                                             #
 #########################################################################################
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import sys
 import logging
 import threading

--- a/tango_simlib/main.py
+++ b/tango_simlib/main.py
@@ -7,6 +7,10 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
+from __future__ import unicode_literals
+from future import standard_library
+standard_library.install_aliases()
+from builtins import *
 import sys
 import logging
 import threading

--- a/tango_simlib/model.py
+++ b/tango_simlib/model.py
@@ -1,11 +1,19 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
+from __future__ import unicode_literals
 #########################################################################################
 # Copyright 2017 SKA South Africa (http://ska.ac.za/)                                   #
 #                                                                                       #
 # BSD license - see LICENSE.txt for details                                             #
 #########################################################################################
+from future import standard_library
+standard_library.install_aliases()
+from builtins import str
+from builtins import map
+from builtins import range
+from builtins import *
+from builtins import object
 import logging
 import time
 import weakref
@@ -105,7 +113,7 @@ class Model(object):
         """
         self._sim_state.update(
             {var: (quant.last_val, quant.last_update_time)
-             for var, quant in self.sim_quantities.items()})
+             for var, quant in list(self.sim_quantities.items())})
 
     def update(self):
         sim_time = self.time_func()
@@ -113,7 +121,7 @@ class Model(object):
         if dt < self.min_update_period or self.paused:
             # Updating the sim_state in case the test interface or external command
             # updated the quantities.
-            for var, quant in self.sim_quantities.items():
+            for var, quant in list(self.sim_quantities.items()):
                 self._sim_state[var] = (quant.last_val, quant.last_update_time)
             MODULE_LOGGER.debug(
                 "Sim {} skipping update at {}, dt {} < {} and pause {}"
@@ -126,7 +134,7 @@ class Model(object):
         MODULE_LOGGER.info("Stepping at {}, dt: {}".format(sim_time, dt))
         self.last_update_time = sim_time
         try:
-            for var, quant in self.sim_quantities.items():
+            for var, quant in list(self.sim_quantities.items()):
                 self._sim_state[var] = (quant.next_val(sim_time), sim_time)
         except Exception:
             MODULE_LOGGER.exception('Exception in update loop')
@@ -210,7 +218,7 @@ class PopulateModelQuantities(object):
         start_time = self.sim_model.start_time
         attributes = self.parser_instance.get_device_attribute_metadata()
 
-        for attr_name, attr_props in attributes.items():
+        for attr_name, attr_props in list(attributes.items()):
             # When using more than one config file, the attribute meta data can be
             # overwritten, so we need to update it instead of reassigning a different
             # object.
@@ -228,9 +236,9 @@ class PopulateModelQuantities(object):
                 # props template are removed.
                 # i.e. All optional parameters not provided in the SimDD
                 attr_props = dict((param_key, param_val)
-                                  for param_key, param_val in attr_props.iteritems()
+                                  for param_key, param_val in attr_props.items()
                                   if param_val)
-                model_attr_props = dict(model_attr_props.items() + attr_props.items())
+                model_attr_props = dict(list(model_attr_props.items()) + list(attr_props.items()))
 
             if 'quantity_simulation_type' in model_attr_props:
                 if model_attr_props['quantity_simulation_type'] == 'ConstantQuantity':
@@ -279,7 +287,7 @@ class PopulateModelQuantities(object):
                             start_time=start_time, meta=model_attr_props,
                             **sim_attr_quantities)
             else:
-                key_vals = model_attr_props.keys()
+                key_vals = list(model_attr_props.keys())
                 attr_data_type = model_attr_props['data_type']
                 # the xmi, json and fgo files have data_format attributes indicating
                 # SPECTRUM, SCALAR OR IMAGE data formats. The xml file does not have this
@@ -317,7 +325,7 @@ class PopulateModelQuantities(object):
                     if attr_data_format == 'SCALAR':
                         default_val = val_type(default_val)
                     elif attr_data_format == 'SPECTRUM':
-                        default_val = map(val_type, default_val)
+                        default_val = list(map(val_type, default_val))
                     else:
                         default_val = [[val_type(curr_val) for curr_val in sublist]
                                        for sublist in default_val]
@@ -423,7 +431,7 @@ class PopulateModelActions(object):
             else:
                 self.sim_model.override_post_updates.append(post_update_overwrite)
 
-        for cmd_name, cmd_meta in self.cmd_info.items():
+        for cmd_name, cmd_meta in list(self.cmd_info.items()):
             # Exclude the TANGO default commands as they have their own built in handlers
             # provided.
             if cmd_name in DEFAULT_TANGO_COMMANDS:
@@ -470,7 +478,7 @@ class PopulateModelActions(object):
 
     def _get_class_instances(self, override_class_info):
         instances = {}
-        for klass_info in override_class_info.values():
+        for klass_info in list(override_class_info.values()):
             if klass_info['module_directory'] == 'None':
                 module = importlib.import_module(klass_info['module_name'])
             else:

--- a/tango_simlib/model.py
+++ b/tango_simlib/model.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 #########################################################################################
 # Copyright 2017 SKA South Africa (http://ska.ac.za/)                                   #
 #                                                                                       #
@@ -229,7 +232,7 @@ class PopulateModelQuantities(object):
                                   if param_val)
                 model_attr_props = dict(model_attr_props.items() + attr_props.items())
 
-            if model_attr_props.has_key('quantity_simulation_type'):
+            if 'quantity_simulation_type' in model_attr_props:
                 if model_attr_props['quantity_simulation_type'] == 'ConstantQuantity':
                     try:
                         initial_value = model_attr_props['initial_value']

--- a/tango_simlib/quantities.py
+++ b/tango_simlib/quantities.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 ######################################################################################### 
 # Copyright 2017 SKA South Africa (http://ska.ac.za/)                                   #
 #                                                                                       #

--- a/tango_simlib/sim_test_interface.py
+++ b/tango_simlib/sim_test_interface.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 ######################################################################################### 
 # Copyright 2017 SKA South Africa (http://ska.ac.za/)                                   #
 #                                                                                       #

--- a/tango_simlib/tango_launcher.py
+++ b/tango_simlib/tango_launcher.py
@@ -9,6 +9,9 @@
 Helps by auto-registering a TANGO device if needed.
 
 """
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import os
 import sys
 import argparse
@@ -45,14 +48,14 @@ def register_device(name, device_class, server_name, instance, db):
     dev_info.name = name
     dev_info._class = device_class
     dev_info.server = "{}/{}".format(server_name.split('.')[0], instance)
-    print """Attempting to register TANGO device {!r}
+    print("""Attempting to register TANGO device {!r}
     class: {!r}  server: {!r}.""".format(
-        dev_info.name, dev_info._class, dev_info.server)
+        dev_info.name, dev_info._class, dev_info.server))
     db.add_device(dev_info)
 
 def put_device_property(dev_name, property_name, property_value, db):
-    print "Setting device {!r} property {!r}: {!r}".format(
-        dev_name, property_name, property_value)
+    print("Setting device {!r} property {!r}: {!r}".format(
+        dev_name, property_name, property_value))
     db.put_device_property(dev_name, {property_name:[property_value]})
 
 def start_device(opts):
@@ -81,8 +84,8 @@ def start_device(opts):
         args = ['python %s' % opts.server_command, opts.server_instance]
         if opts.file_name:
             args.append('-file={}'.format(opts.file_name))
-        print "Starting TANGO device server:\n{}".format(
-              " ".join(["{!r}".format(arg) for arg in args]))
+        print("Starting TANGO device server:\n{}".format(
+              " ".join(["{!r}".format(arg) for arg in args])))
         sys.stdout.flush()
         sys.stderr.flush()
         os.system(" ".join(args))
@@ -92,8 +95,8 @@ def start_device(opts):
                '-ORBendPoint', 'giop:tcp::{}'.format(opts.port)]
         if opts.file_name:
             args.append('-file={}'.format(opts.file_name))
-        print "Starting TANGO device server:\n{}".format(
-              " ".join(["{!r}".format(arg) for arg in args]))
+        print("Starting TANGO device server:\n{}".format(
+              " ".join(["{!r}".format(arg) for arg in args])))
         sys.stdout.flush()
         sys.stderr.flush()
         os.execvp(opts.server_command, args)

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -8,6 +8,9 @@
 Simlib library generic simulator generator utility to be used to generate an actual
 TANGO device that exhibits the behaviour defined in the data description file.
 """
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 import os
 import weakref

--- a/tango_simlib/tests/test_dish.py
+++ b/tango_simlib/tests/test_dish.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 ######################################################################################### 
 # Author: cam@ska.ac.za                                                                 #
 # Copyright 2018 SKA South Africa (http://ska.ac.za/)                                   #

--- a/tango_simlib/tests/test_fandango_json_parser.py
+++ b/tango_simlib/tests/test_fandango_json_parser.py
@@ -5,6 +5,9 @@
 #########################################################################################
 """This module tests the fandango_json_parser script.
 """
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import unittest
 import logging
 import pkg_resources

--- a/tango_simlib/tests/test_quantities.py
+++ b/tango_simlib/tests/test_quantities.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 ######################################################################################### 
 # Author: cam@ska.ac.za                                                                 #
 # Copyright 2018 SKA South Africa (http://ska.ac.za/)                                   #

--- a/tango_simlib/tests/test_sim_sdd_xml_parser.py
+++ b/tango_simlib/tests/test_sim_sdd_xml_parser.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 ######################################################################################### 
 # Author: cam@ska.ac.za                                                                 #
 # Copyright 2018 SKA South Africa (http://ska.ac.za/)                                   #
@@ -151,7 +154,7 @@ class test_PopModelQuantities(GenericSetup):
             sim_quantity_metadata = getattr(sim_quantity, 'meta')
             mpt_meta = mnt_pt_metadata[sim_quantity_name]
             for mnt_pt_param_name, mnt_pt_param_val in mpt_meta.items():
-                self.assertTrue(sim_quantity_metadata.has_key(mnt_pt_param_name),
+                self.assertTrue(mnt_pt_param_name in sim_quantity_metadata,
                                 "The param '%s' was not added to the model quantity"
                                 " '%s'" % (mnt_pt_param_name, sim_quantity_name))
                 self.assertEqual(sim_quantity_metadata[mnt_pt_param_name],

--- a/tango_simlib/tests/test_sim_test_interface.py
+++ b/tango_simlib/tests/test_sim_test_interface.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 ######################################################################################### 
 # Author: cam@ska.ac.za                                                                 #
 # Copyright 2018 SKA South Africa (http://ska.ac.za/)                                   #

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 ######################################################################################### 
 # Author: cam@ska.ac.za                                                                 #
 # Copyright 2018 SKA South Africa (http://ska.ac.za/)                                   #
@@ -557,7 +560,7 @@ class test_PopModelActions(GenericSetup):
             # Exclude the State and Status command (cmd_handlers for them are created
             # automatically by TANGO
             if cmd_name not in ['State', 'Status']:
-                self.assertTrue(sim_model.sim_actions.has_key(cmd_name),
+                self.assertTrue(cmd_name in sim_model.sim_actions,
                                 "The an action handler for the cmd '%s' was not created" %
                                 (cmd_name))
 

--- a/tango_simlib/tests/test_simdd_json_parser.py
+++ b/tango_simlib/tests/test_simdd_json_parser.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 ######################################################################################### 
 # Author: cam@ska.ac.za                                                                 #
 # Copyright 2018 SKA South Africa (http://ska.ac.za/)                                   #
@@ -171,7 +174,7 @@ class test_PopulateModelQuantities(GenericSetup):
             sim_quantity_metadata = getattr(sim_quantity, 'meta')
             attr_meta = attribute_metadata[sim_quantity_name]
             for attr_param_name, attr_param_val in attr_meta.items():
-                self.assertTrue(sim_quantity_metadata.has_key(attr_param_name),
+                self.assertTrue(attr_param_name in sim_quantity_metadata,
                                 "The param '%s' was not added to the model quantity"
                                 " '%s'" % (attr_param_name, sim_quantity_name))
                 self.assertEqual(
@@ -252,7 +255,7 @@ class test_PopulateModelActions(GenericSetup):
         override_info = self.simdd_parser.get_device_cmd_override_metadata()
         model.PopulateModelActions(cmd_info, override_info, device_name, sim_model)
         action_on = sim_model.sim_actions['On']
-        self.assertEqual(action_on.func.im_class, override_class.OverrideWeather)
+        self.assertEqual(action_on.func.__self__.__class__, override_class.OverrideWeather)
 
     def test_model_action_behaviour(self):
         device_name = 'tango/device/instance'

--- a/tango_simlib/tests/test_simdd_json_parser.py
+++ b/tango_simlib/tests/test_simdd_json_parser.py
@@ -1,7 +1,8 @@
 from __future__ import print_function
 from __future__ import division
 from __future__ import absolute_import
-######################################################################################### 
+
+#########################################################################################
 # Author: cam@ska.ac.za                                                                 #
 # Copyright 2018 SKA South Africa (http://ska.ac.za/)                                   #
 #                                                                                       #
@@ -26,71 +27,78 @@ from tango_simlib.utilities.testutils import cleanup_tempfile, ClassCleanupUnitt
 MODULE_LOGGER = logging.getLogger(__name__)
 
 TANGO_CMD_PARAMS_NAME_MAP = {
-    'name': 'cmd_name',
-    'doc_in': 'in_type_desc',
-    'dtype_in': 'in_type',
-    'doc_out': 'out_type_desc',
-    'dtype_out': 'out_type'}
+    "name": "cmd_name",
+    "doc_in": "in_type_desc",
+    "dtype_in": "in_type",
+    "doc_out": "out_type_desc",
+    "dtype_out": "out_type",
+}
 
 # Mandatory parameters required to create a well configure Tango command.
-EXPECTED_MANDATORY_CMD_PARAMETERS = frozenset([
-    'dformat_in', 'dformat_out', 'doc_in',
-    'doc_out', 'dtype_in', 'dtype_out', 'name', ])
+EXPECTED_MANDATORY_CMD_PARAMETERS = frozenset(
+    ["dformat_in", "dformat_out", "doc_in", "doc_out", "dtype_in", "dtype_out", "name"]
+)
 
 # Mandatory parameters required by each override_class.
-EXPECTED_MANDATORY_OVERRIDE_CLASS_PARAMETERS = frozenset([
-    'class_name', 'module_directory', 'module_name', 'name'])
+EXPECTED_MANDATORY_OVERRIDE_CLASS_PARAMETERS = frozenset(
+    ["class_name", "module_directory", "module_name", "name"]
+)
 
 # The desired information for the attribute temperature when the Weather_SimDD
 # json file is parsed by the SimddParser.
 EXPECTED_TEMPERATURE_ATTR_INFO = {
-        'abs_change': '0.5',
-        'archive_abs_change': '0.5',
-        'archive_period': '1000',
-        'archive_rel_change': '10',
-        'data_format': 'Scalar',
-        'data_type': tango._tango.CmdArgType.DevDouble,
-        'format': '6.2f',
-        'delta_t': '1000',
-        'delta_val': '0.5',
-        'description': 'Current actual temperature outside near the telescope.',
-        'display_level': 'OPERATOR',
-        'event_period': '1000',
-        'label': 'Outside Temperature',
-        'max_alarm': '50',
-        'max_bound': '50',
-        'max_dim_x': '1',
-        'max_dim_y': '0',
-        'max_slew_rate': '1',
-        'max_value': '51',
-        'mean': '25',
-        'min_alarm': '-9',
-        'min_bound': '-10',
-        'min_value': '-10',
-        'min_warning': '-8',
-        'max_warning': '49',
-        'name': 'temperature',
-        'quantity_simulation_type': 'GaussianSlewLimited',
-        'period': '1000',
-        'rel_change': '10',
-        'std_dev': '5',
-        'unit': 'Degrees Centrigrade',
-        'update_period': '1000',
-        'writable': 'READ'
-    }
+    "abs_change": "0.5",
+    "archive_abs_change": "0.5",
+    "archive_period": "1000",
+    "archive_rel_change": "10",
+    "data_format": "Scalar",
+    "data_type": tango._tango.CmdArgType.DevDouble,
+    "format": "6.2f",
+    "delta_t": "1000",
+    "delta_val": "0.5",
+    "description": "Current actual temperature outside near the telescope.",
+    "display_level": "OPERATOR",
+    "event_period": "1000",
+    "label": "Outside Temperature",
+    "max_alarm": "50",
+    "max_bound": "50",
+    "max_dim_x": "1",
+    "max_dim_y": "0",
+    "max_slew_rate": "1",
+    "max_value": "51",
+    "mean": "25",
+    "min_alarm": "-9",
+    "min_bound": "-10",
+    "min_value": "-10",
+    "min_warning": "-8",
+    "max_warning": "49",
+    "name": "temperature",
+    "quantity_simulation_type": "GaussianSlewLimited",
+    "period": "1000",
+    "rel_change": "10",
+    "std_dev": "5",
+    "unit": "Degrees Centrigrade",
+    "update_period": "1000",
+    "writable": "READ",
+}
 
 
 class GenericSetup(unittest.TestCase):
     """A class providing the setUp method definition for the other test classes.
     """
+
     longMessage = True
 
     def setUp(self):
         super(GenericSetup, self).setUp()
-        self.simdd_json_file = [pkg_resources.resource_filename(
-            'tango_simlib.tests.config_files', 'Weather_SimDD.json')]
+        self.simdd_json_file = [
+            pkg_resources.resource_filename(
+                "tango_simlib.tests.config_files", "Weather_SimDD.json"
+            )
+        ]
         self.simdd_parser = simdd_json_parser.SimddParser()
         self.simdd_parser.parse(self.simdd_json_file[0])
+
 
 class test_SimddJsonParser(GenericSetup):
     """A test class that tests that the SimddJsonParser works correctly.
@@ -101,36 +109,54 @@ class test_SimddJsonParser(GenericSetup):
         in the SimDD json file.
         """
         actual_parsed_attrs = self.simdd_parser.get_device_attribute_metadata()
-        expected_attr_list = ['input-comms-ok', 'insolation', 'pressure', 'rainfall',
-                              'relative-humidity', 'temperature', 'wind-direction',
-                              'wind-speed']
+        expected_attr_list = [
+            "input-comms-ok",
+            "insolation",
+            "pressure",
+            "rainfall",
+            "relative-humidity",
+            "temperature",
+            "wind-direction",
+            "wind-speed",
+        ]
         actual_parsed_attr_list = sorted(actual_parsed_attrs.keys())
         self.assertGreater(
-            len(actual_parsed_attr_list), 0, "There is no attribute information parsed")
-        self.assertEquals(set(expected_attr_list), set(actual_parsed_attr_list),
-                          'There are missing attributes')
+            len(actual_parsed_attr_list), 0, "There is no attribute information parsed"
+        )
+        self.assertEquals(
+            set(expected_attr_list),
+            set(actual_parsed_attr_list),
+            "There are missing attributes",
+        )
 
         # Test if all the parsed attributes have the mandatory properties
         for attr_name, attribute_metadata in actual_parsed_attrs.items():
             for param in helper_module.DEFAULT_TANGO_ATTRIBUTE_PARAMETER_TEMPLATE.keys():
                 self.assertIn(
-                    param, attribute_metadata.keys(),
+                    param,
+                    attribute_metadata.keys(),
                     "The parsed attribute '%s' does not have the mandotory parameter "
-                    "'%s' " % (attr_name, param))
+                    "'%s' " % (attr_name, param),
+                )
 
         # Using the made up temperature attribute expected results as we
         # haven't generated the full test data for the other attributes.
-        self.assertIn('temperature', actual_parsed_attrs.keys(),
-                      "The attribute temperature is not in the parsed attribute list")
-        actual_parsed_temperature_attr_info = actual_parsed_attrs['temperature']
+        self.assertIn(
+            "temperature",
+            actual_parsed_attrs.keys(),
+            "The attribute temperature is not in the parsed attribute list",
+        )
+        actual_parsed_temperature_attr_info = actual_parsed_attrs["temperature"]
 
         # Compare the values of the attribute properties captured in the POGO
         # generated xmi file and the ones in the parsed attribute data structure.
         for prop in EXPECTED_TEMPERATURE_ATTR_INFO:
-            self.assertEquals(actual_parsed_temperature_attr_info[prop],
-                              EXPECTED_TEMPERATURE_ATTR_INFO[prop],
-                              "The expected value for the parameter '%s' does "
-                              "not match with the actual value" % (prop))
+            self.assertEquals(
+                actual_parsed_temperature_attr_info[prop],
+                EXPECTED_TEMPERATURE_ATTR_INFO[prop],
+                "The expected value for the parameter '%s' does "
+                "not match with the actual value" % (prop),
+            )
 
     def test_parsed_override_info(self):
         """Testing that the class override information parsed matches with the one
@@ -139,50 +165,71 @@ class test_SimddJsonParser(GenericSetup):
         actual_override_info = self.simdd_parser.get_device_cmd_override_metadata()
         for klass_info in actual_override_info.values():
             for param in EXPECTED_MANDATORY_OVERRIDE_CLASS_PARAMETERS:
-                self.assertIn(param, klass_info.keys(), "Class override info missing"
-                              " some important parameter.")
+                self.assertIn(
+                    param,
+                    klass_info.keys(),
+                    "Class override info missing" " some important parameter.",
+                )
+
 
 class test_PopulateModelQuantities(GenericSetup):
-
     def test_model_quantities(self):
         """Testing that the model quantities that are added to the model match with
         the attributes specified in the XMI file.
         """
-        device_name = 'tango/device/instance'
+        device_name = "tango/device/instance"
         pmq = model.PopulateModelQuantities(self.simdd_parser, device_name)
-        self.assertEqual(device_name, pmq.sim_model.name,
-                         "The device name and the model name do not match.")
-        expected_quantities_list = ['insolation', 'temperature',
-                                    'pressure', 'input-comms-ok',
-                                    'rainfall', 'relative-humidity',
-                                    'wind-direction', 'wind-speed']
+        self.assertEqual(
+            device_name,
+            pmq.sim_model.name,
+            "The device name and the model name do not match.",
+        )
+        expected_quantities_list = [
+            "insolation",
+            "temperature",
+            "pressure",
+            "input-comms-ok",
+            "rainfall",
+            "relative-humidity",
+            "wind-direction",
+            "wind-speed",
+        ]
         actual_quantities_list = pmq.sim_model.sim_quantities.keys()
-        self.assertEqual(set(expected_quantities_list), set(actual_quantities_list),
-                         "The are quantities missing in the model")
+        self.assertEqual(
+            set(expected_quantities_list),
+            set(actual_quantities_list),
+            "The are quantities missing in the model",
+        )
 
     def test_model_quantities_metadata(self):
         """Testing that the metadata of the quantities matches with the metadata
         data of the parsed attribute data captured in the SDD xml file.
         """
-        device_name = 'tango/device/instance'
+        device_name = "tango/device/instance"
         pmq = model.PopulateModelQuantities(self.simdd_parser, device_name)
-        self.assertEqual(device_name, pmq.sim_model.name,
-                         "The device name and the model name do not match.")
+        self.assertEqual(
+            device_name,
+            pmq.sim_model.name,
+            "The device name and the model name do not match.",
+        )
         attribute_metadata = self.simdd_parser.get_device_attribute_metadata()
-        for sim_quantity_name, sim_quantity in (
-                pmq.sim_model.sim_quantities.items()):
-            sim_quantity_metadata = getattr(sim_quantity, 'meta')
+        for sim_quantity_name, sim_quantity in pmq.sim_model.sim_quantities.items():
+            sim_quantity_metadata = getattr(sim_quantity, "meta")
             attr_meta = attribute_metadata[sim_quantity_name]
             for attr_param_name, attr_param_val in attr_meta.items():
-                self.assertTrue(attr_param_name in sim_quantity_metadata,
-                                "The param '%s' was not added to the model quantity"
-                                " '%s'" % (attr_param_name, sim_quantity_name))
+                self.assertTrue(
+                    attr_param_name in sim_quantity_metadata,
+                    "The param '%s' was not added to the model quantity"
+                    " '%s'" % (attr_param_name, sim_quantity_name),
+                )
                 self.assertEqual(
-                    sim_quantity_metadata[attr_param_name], attr_param_val,
+                    sim_quantity_metadata[attr_param_name],
+                    attr_param_val,
                     "The value of the param '%s' in the model quantity '%s' is "
                     "not the same with the one captured in the SDD xml file "
-                    "for the monitoring point '%s'." % (
-                        attr_param_name, sim_quantity_name, attr_param_name))
+                    "for the monitoring point '%s'."
+                    % (attr_param_name, sim_quantity_name, attr_param_name),
+                )
 
 
 EXPECTED_ACTION_SET_TEMPERATURE_METADATA = {
@@ -195,23 +242,23 @@ EXPECTED_ACTION_SET_TEMPERATURE_METADATA = {
     "doc_out": "Command responds",
     "dformat_out": "",
     "actions": [
-        {"behaviour": "input_transform",
-         "destination_variable": "temporary_variable"},
-        {"behaviour": "side_effect",
-         "source_variable": "temporary_variable",
-         "destination_quantity": "temperature"},
-        {"behaviour": "output_return",
-         "source_variable": "temporary_variable"}]
+        {"behaviour": "input_transform", "destination_variable": "temporary_variable"},
+        {
+            "behaviour": "side_effect",
+            "source_variable": "temporary_variable",
+            "destination_quantity": "temperature",
+        },
+        {"behaviour": "output_return", "source_variable": "temporary_variable"},
+    ],
 }
 
 
 class test_PopulateModelActions(GenericSetup):
-
     def test_model_actions(self):
         """Testing that the model actions that are added to the model match with
         the commands specified in the XMI file.
         """
-        device_name = 'tango/device/instance'
+        device_name = "tango/device/instance"
         pmq = model.PopulateModelQuantities(self.simdd_parser, device_name)
         sim_model = pmq.sim_model
         cmd_info = self.simdd_parser.get_device_command_metadata()
@@ -219,15 +266,25 @@ class test_PopulateModelActions(GenericSetup):
         model.PopulateModelActions(cmd_info, override_info, device_name, sim_model)
 
         actual_actions_list = sim_model.sim_actions.keys()
-        expected_actions_list = ['On', 'Off', 'StopRainfall', 'SetTemperature', 'Add',
-                                 'StopQuantitySimulation', 'MultiplyStringBy3']
-        self.assertEqual(set(actual_actions_list), set(expected_actions_list),
-                         "There are actions missing in the model")
+        expected_actions_list = [
+            "On",
+            "Off",
+            "StopRainfall",
+            "SetTemperature",
+            "Add",
+            "StopQuantitySimulation",
+            "MultiplyStringBy3",
+        ]
+        self.assertEqual(
+            set(actual_actions_list),
+            set(expected_actions_list),
+            "There are actions missing in the model",
+        )
 
     def test_model_actions_metadata(self):
         """Testing that the model action metadata has been added correctly to the model.
         """
-        device_name = 'tango/device/instance'
+        device_name = "tango/device/instance"
         pmq = model.PopulateModelQuantities(self.simdd_parser, device_name)
         sim_model = pmq.sim_model
         cmd_info = self.simdd_parser.get_device_command_metadata()
@@ -238,33 +295,40 @@ class test_PopulateModelActions(GenericSetup):
         for cmd_name, cmd_metadata in cmd_info.items():
             model_act_meta = sim_model_actions_meta[cmd_name]
             for action_parameter in EXPECTED_MANDATORY_CMD_PARAMETERS:
-                self.assertIn(action_parameter, model_act_meta,
-                              "The parameter is not in the action's metadata")
-            self.assertEqual(cmd_metadata, model_act_meta,
-                             "The action's %s metadata was not processed correctly" %
-                             cmd_name)
+                self.assertIn(
+                    action_parameter,
+                    model_act_meta,
+                    "The parameter is not in the action's metadata",
+                )
+            self.assertEqual(
+                cmd_metadata,
+                model_act_meta,
+                "The action's %s metadata was not processed correctly" % cmd_name,
+            )
 
     def test_model_actions_overrides(self):
         """Testing that the On command defined in the SimDD file is mapped to the
         correct user-defined action handler provided in the override class.
         """
-        device_name = 'tango/device/instance'
+        device_name = "tango/device/instance"
         pmq = model.PopulateModelQuantities(self.simdd_parser, device_name)
         sim_model = pmq.sim_model
         cmd_info = self.simdd_parser.get_device_command_metadata()
         override_info = self.simdd_parser.get_device_cmd_override_metadata()
         model.PopulateModelActions(cmd_info, override_info, device_name, sim_model)
-        action_on = sim_model.sim_actions['On']
-        self.assertEqual(action_on.func.__self__.__class__, override_class.OverrideWeather)
+        action_on = sim_model.sim_actions["On"]
+        self.assertEqual(
+            action_on.func.__self__.__class__, override_class.OverrideWeather
+        )
 
     def test_model_action_behaviour(self):
-        device_name = 'tango/device/instance'
+        device_name = "tango/device/instance"
         pmq = model.PopulateModelQuantities(self.simdd_parser, device_name)
         sim_model = pmq.sim_model
         cmd_info = self.simdd_parser.get_device_command_metadata()
         override_info = self.simdd_parser.get_device_cmd_override_metadata()
         model.PopulateModelActions(cmd_info, override_info, device_name, sim_model)
-        action_set_temperature = sim_model.sim_actions['SetTemperature']
+        action_set_temperature = sim_model.sim_actions["SetTemperature"]
         data_in = 25.00
         self.assertEqual(action_set_temperature(data_in), data_in)
 
@@ -275,17 +339,22 @@ class test_SimddDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase):
 
     @classmethod
     def setUpClassWithCleanup(cls):
-        cls.tango_db = cleanup_tempfile(cls, prefix='tango', suffix='.db')
-        cls.data_descr_file = [pkg_resources.resource_filename(
-            'tango_simlib.tests.config_files', 'Weather_SimDD.json')]
-        cls.device_name = 'test/nodb/tangodeviceserver'
-        model = tango_sim_generator.configure_device_models(cls.data_descr_file,
-                                                           cls.device_name)
+        cls.tango_db = cleanup_tempfile(cls, prefix="tango", suffix=".db")
+        cls.data_descr_file = [
+            pkg_resources.resource_filename(
+                "tango_simlib.tests.config_files", "Weather_SimDD.json"
+            )
+        ]
+        cls.device_name = "test/nodb/tangodeviceserver"
+        model = tango_sim_generator.configure_device_models(
+            cls.data_descr_file, cls.device_name
+        )
         cls.TangoDeviceServer = tango_sim_generator.get_tango_device_server(
-                    model, cls.data_descr_file)[0]
-        cls.tango_context = DeviceTestContext(cls.TangoDeviceServer,
-                                              device_name=cls.device_name,
-                                              db=cls.tango_db)
+            model, cls.data_descr_file
+        )[0]
+        cls.tango_context = DeviceTestContext(
+            cls.TangoDeviceServer, device_name=cls.device_name, db=cls.tango_db
+        )
         start_thread_with_cleanup(cls, cls.tango_context)
 
     def setUp(self):
@@ -299,17 +368,19 @@ class test_SimddDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase):
 
         default_metadata_values = {}
         for quantity in self.instance.model.sim_quantities.keys():
-            if hasattr(self.instance.model.sim_quantities[quantity], 'max_bound'):
-                default_metadata_values[quantity] = (
-                    self.instance.model.sim_quantities[quantity].max_bound)
+            if hasattr(self.instance.model.sim_quantities[quantity], "max_bound"):
+                default_metadata_values[quantity] = self.instance.model.sim_quantities[
+                    quantity
+                ].max_bound
 
         self.addCleanup(self._restore_model, default_metadata_values)
 
     def _restore_model(self, default_metadata_values):
         for quantity in self.instance.model.sim_quantities.keys():
-            if hasattr(self.instance.model.sim_quantities[quantity], 'max_bound'):
-                self.instance.model.sim_quantities[quantity].max_bound = (
-                    default_metadata_values[quantity])
+            if hasattr(self.instance.model.sim_quantities[quantity], "max_bound"):
+                self.instance.model.sim_quantities[
+                    quantity
+                ].max_bound = default_metadata_values[quantity]
 
     def test_attribute_list(self):
         """ Testing whether the attributes specified in the POGO generated xmi file
@@ -319,11 +390,14 @@ class test_SimddDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase):
         expected_attributes = []
         default_attributes = helper_module.DEFAULT_TANGO_DEVICE_ATTRIBUTES
         expected_attributes = (
-            self.simdd_json_parser.get_device_attribute_metadata().keys())
+            self.simdd_json_parser.get_device_attribute_metadata().keys()
+        )
 
-        self.assertEqual(set(expected_attributes), attributes - default_attributes,
-                         "Actual tango device attribute list differs from expected "
-                         "list!")
+        self.assertEqual(
+            set(expected_attributes),
+            attributes - default_attributes,
+            "Actual tango device attribute list differs from expected " "list!",
+        )
 
     def test_command_list(self):
         """Testing that the command list in the Tango device matches with the one
@@ -331,19 +405,21 @@ class test_SimddDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase):
         """
         actual_device_commands = set(self.device.get_command_list())
         expected_command_list = (
-            self.simdd_json_parser.get_device_command_metadata().keys())
+            self.simdd_json_parser.get_device_command_metadata().keys()
+        )
         expected_command_list.extend(helper_module.DEFAULT_TANGO_DEVICE_COMMANDS)
-        self.assertEquals(actual_device_commands, set(expected_command_list),
-                          "The commands specified in the SimDD file are not present in"
-                          " the device")
+        self.assertEquals(
+            actual_device_commands,
+            set(expected_command_list),
+            "The commands specified in the SimDD file are not present in" " the device",
+        )
 
     def test_command_properties(self):
         """Testing that the command parameter information matches with the information
         captured in the SimDD data description file.
         """
         command_data = self.simdd_json_parser.get_device_command_metadata()
-        extra_command_parameters = ['dformat_in', 'dformat_out', 'description',
-                                    'actions']
+        extra_command_parameters = ["dformat_in", "dformat_out", "description", "actions"]
         for cmd_name, cmd_metadata in command_data.items():
             cmd_config_info = self.device.get_command_config(cmd_name)
             for cmd_prop, cmd_prop_value in cmd_metadata.items():
@@ -353,84 +429,116 @@ class test_SimddDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase):
                     continue
                 self.assertTrue(
                     hasattr(cmd_config_info, TANGO_CMD_PARAMS_NAME_MAP[cmd_prop]),
-                    "The cmd parameter '%s' for the cmd '%s' was not translated" %
-                    (cmd_prop, cmd_name))
-                if cmd_prop_value == 'none' or cmd_prop_value == '':
-                    cmd_prop_value = 'Uninitialised'
+                    "The cmd parameter '%s' for the cmd '%s' was not translated"
+                    % (cmd_prop, cmd_name),
+                )
+                if cmd_prop_value == "none" or cmd_prop_value == "":
+                    cmd_prop_value = "Uninitialised"
                 self.assertEqual(
                     getattr(cmd_config_info, TANGO_CMD_PARAMS_NAME_MAP[cmd_prop]),
-                    cmd_prop_value, "The cmd %s parameter '%s/%s' values do not match" %
-                    (cmd_name, cmd_prop, TANGO_CMD_PARAMS_NAME_MAP[cmd_prop]))
+                    cmd_prop_value,
+                    "The cmd %s parameter '%s/%s' values do not match"
+                    % (cmd_name, cmd_prop, TANGO_CMD_PARAMS_NAME_MAP[cmd_prop]),
+                )
 
     def test_On_command(self):
         """Testing that the On command changes the value of the State attribute of the
         Tango device to ON.
         """
-        command_name = 'On'
+        command_name = "On"
         expected_result = None
         self.device.command_inout(command_name)
-        self.assertEqual(self.device.command_inout(command_name),
-                         expected_result)
-        self.assertEqual(getattr(self.device.read_attribute('State'), 'value'),
-                         tango.DevState.ON)
+        self.assertEqual(self.device.command_inout(command_name), expected_result)
+        self.assertEqual(
+            getattr(self.device.read_attribute("State"), "value"), tango.DevState.ON
+        )
 
     def test_Add_command(self):
         """Testing that the Tango device command can take input of an array type and
         return a output value of type double.
         """
-        command_name = 'Add'
+        command_name = "Add"
         command_args = [12, 45, 53, 32, 2.1, 0.452]
         expected_return_value = 144.552
         actual_return_value = self.device.command_inout(command_name, command_args)
-        self.assertEqual(expected_return_value, actual_return_value, "The actual return"
-                         "value does not match with the expected return value.")
+        self.assertEqual(
+            expected_return_value,
+            actual_return_value,
+            "The actual return" "value does not match with the expected return value.",
+        )
 
     def test_MultiplyStringBy3_command(self):
         """Testing that the Tango device command can take input of type string and
         return an output value of type string.
         """
-        command_name = 'MultiplyStringBy3'
-        command_args = 'LMC'
-        expected_return_value = 'LMCLMCLMC'
+        command_name = "MultiplyStringBy3"
+        command_args = "LMC"
+        expected_return_value = "LMCLMCLMC"
         actual_return_value = self.device.command_inout(command_name, command_args)
-        self.assertEqual(expected_return_value, actual_return_value, "The actual return"
-                         "value does not match with the expected return value.")
+        self.assertEqual(
+            expected_return_value,
+            actual_return_value,
+            "The actual return" "value does not match with the expected return value.",
+        )
 
     def test_Off_command(self):
         """Testing that the Off command changes the State attribute's value of the Tango
         device to OFF.
         """
-        command_name = 'Off'
+        command_name = "Off"
         expected_result = None
-        self.assertEqual(self.device.command_inout(command_name),
-                         expected_result)
-        self.assertEqual(getattr(self.device.read_attribute('State'), 'value'),
-                         tango.DevState.OFF)
+        self.assertEqual(self.device.command_inout(command_name), expected_result)
+        self.assertEqual(
+            getattr(self.device.read_attribute("State"), "value"), tango.DevState.OFF
+        )
 
     def test_set_temperature_command(self):
         """Testing that the SetTemperature command changes the temperature
         attribute's value of the Tango device to the specified input parameter.
         """
-        command_name = 'SetTemperature'
+        command_name = "SetTemperature"
         data_in = 25.0
         expected_result = data_in
-        self.assertEqual(self.device.command_inout(command_name, data_in),
-                         expected_result)
+        self.assertEqual(
+            self.device.command_inout(command_name, data_in), expected_result
+        )
         self.instance.model.last_update_time = 0
         # The tango device temperature attribute value return a floating number
         # thus it is rounded to two decimal places before checking if it's the
         # same as the `data_in` value
-        self.assertEqual(round(getattr(self.device.read_attribute('Temperature'),
-                               'value'), 2), data_in)
+        self.assertEqual(
+            round(getattr(self.device.read_attribute("Temperature"), "value"), 2), data_in
+        )
 
 
-MKAT_VDS_ATTRIBUTE_LIST = frozenset(['camera_power_on', 'flood_lights_on',
-                                     'focus_position', 'pan_position', 'pdu_connected',
-                                     'ptz_controller_connected', 'snmpd_trap_running',
-                                     'tilt_position', 'zoom_position'])
-MKAT_VDS_COMMAND_LIST = frozenset(['CameraPowerOn', 'FloodLightOn', 'Focus', 'Pan',
-                                   'PresetClear', 'PresetGoto', 'PresetSet', 'Stop',
-                                   'Tilt', 'Zoom'])
+MKAT_VDS_ATTRIBUTE_LIST = frozenset(
+    [
+        "camera_power_on",
+        "flood_lights_on",
+        "focus_position",
+        "pan_position",
+        "pdu_connected",
+        "ptz_controller_connected",
+        "snmpd_trap_running",
+        "tilt_position",
+        "zoom_position",
+    ]
+)
+MKAT_VDS_COMMAND_LIST = frozenset(
+    [
+        "CameraPowerOn",
+        "FloodLightOn",
+        "Focus",
+        "Pan",
+        "PresetClear",
+        "PresetGoto",
+        "PresetSet",
+        "Stop",
+        "Tilt",
+        "Zoom",
+    ]
+)
+
 
 class test_XmiSimddDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase):
 
@@ -438,21 +546,28 @@ class test_XmiSimddDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCas
 
     @classmethod
     def setUpClassWithCleanup(cls):
-        cls.tango_db = cleanup_tempfile(cls, prefix='tango', suffix='.db')
+        cls.tango_db = cleanup_tempfile(cls, prefix="tango", suffix=".db")
         cls.data_descr_files = []
         cls.data_descr_files.append(
             pkg_resources.resource_filename(
-                'tango_simlib.tests.config_files', 'MkatVds.xmi'))
-        cls.data_descr_files.append(pkg_resources.resource_filename(
-            'tango_simlib.tests.config_files', 'MkatVds_SimDD.json'))
-        cls.device_name = 'test/nodb/tangodeviceserver'
+                "tango_simlib.tests.config_files", "MkatVds.xmi"
+            )
+        )
+        cls.data_descr_files.append(
+            pkg_resources.resource_filename(
+                "tango_simlib.tests.config_files", "MkatVds_SimDD.json"
+            )
+        )
+        cls.device_name = "test/nodb/tangodeviceserver"
         model = tango_sim_generator.configure_device_models(
-            cls.data_descr_files, cls.device_name)
+            cls.data_descr_files, cls.device_name
+        )
         cls.TangoDeviceServer = tango_sim_generator.get_tango_device_server(
-            model, cls.data_descr_files)[0]
-        cls.tango_context = DeviceTestContext(cls.TangoDeviceServer,
-                                              device_name=cls.device_name,
-                                              db=cls.tango_db)
+            model, cls.data_descr_files
+        )[0]
+        cls.tango_context = DeviceTestContext(
+            cls.TangoDeviceServer, device_name=cls.device_name, db=cls.tango_db
+        )
         start_thread_with_cleanup(cls, cls.tango_context)
 
     def setUp(self):
@@ -469,10 +584,14 @@ class test_XmiSimddDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCas
         """
         attributes = set(self.device.get_attribute_list())
         default_attributes = helper_module.DEFAULT_TANGO_DEVICE_ATTRIBUTES
-        self.assertEqual(MKAT_VDS_ATTRIBUTE_LIST, attributes - default_attributes,
-                         "Actual tango device attribute list differs from expected "
-                         "list! \n\n Missing attributes: \n {}".format(
-                            MKAT_VDS_ATTRIBUTE_LIST - attributes))
+        self.assertEqual(
+            MKAT_VDS_ATTRIBUTE_LIST,
+            attributes - default_attributes,
+            "Actual tango device attribute list differs from expected "
+            "list! \n\n Missing attributes: \n {}".format(
+                MKAT_VDS_ATTRIBUTE_LIST - attributes
+            ),
+        )
 
     def test_command_list(self):
         """Testing device command list.
@@ -482,25 +601,32 @@ class test_XmiSimddDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCas
 
         """
         actual_device_commands = set(self.device.get_command_list())
-        self.assertEquals(actual_device_commands -
-                          helper_module.DEFAULT_TANGO_DEVICE_COMMANDS,
-                          MKAT_VDS_COMMAND_LIST,
-                          "The commands specified in the SimDD file are not present in"
-                          " the device")
+        self.assertEquals(
+            actual_device_commands - helper_module.DEFAULT_TANGO_DEVICE_COMMANDS,
+            MKAT_VDS_COMMAND_LIST,
+            "The commands specified in the SimDD file are not present in" " the device",
+        )
 
 
 class test_SourceSimulatorInfo(unittest.TestCase):
     """This class is not testing the code, but only testing that the test XMI and SimDD
     files are consistant with each other.
     """
+
     longMessage = True
 
     def setUp(self):
         super(test_SourceSimulatorInfo, self).setUp()
-        self.sim_xmi_file = [pkg_resources.resource_filename(
-            'tango_simlib.tests.config_files', 'MkatVds.xmi')]
-        self.simdd_json_file = [pkg_resources.resource_filename(
-            'tango_simlib.tests.config_files', 'MkatVds_SimDD.json')]
+        self.sim_xmi_file = [
+            pkg_resources.resource_filename(
+                "tango_simlib.tests.config_files", "MkatVds.xmi"
+            )
+        ]
+        self.simdd_json_file = [
+            pkg_resources.resource_filename(
+                "tango_simlib.tests.config_files", "MkatVds_SimDD.json"
+            )
+        ]
         self.simdd_parser = simdd_json_parser.SimddParser()
         self.xmi_parser = sim_xmi_parser.XmiParser()
         self.xmi_parser.parse(self.sim_xmi_file[0])
@@ -513,22 +639,27 @@ class test_SourceSimulatorInfo(unittest.TestCase):
         information captured in the XMI file generated using POGO.
 
         """
-        xmi_parser_attributes = (
-            self.xmi_parser.get_device_attribute_metadata())
-        simdd_parser_attributes = (
-            self.simdd_parser.get_device_attribute_metadata())
+        xmi_parser_attributes = self.xmi_parser.get_device_attribute_metadata()
+        simdd_parser_attributes = self.simdd_parser.get_device_attribute_metadata()
 
         for attribute_name in MKAT_VDS_ATTRIBUTE_LIST:
-            self.assertIn(attribute_name, xmi_parser_attributes,
-                          "The attribute '{}' is missing from the file: '{}'.".
-                          format(attribute_name, self.sim_xmi_file[0]))
+            self.assertIn(
+                attribute_name,
+                xmi_parser_attributes,
+                "The attribute '{}' is missing from the file: '{}'.".format(
+                    attribute_name, self.sim_xmi_file[0]
+                ),
+            )
 
         for attribute_name in simdd_parser_attributes:
-            self.assertIn(attribute_name, xmi_parser_attributes,
-                          "The attribute '{}' specified in the file: '{}' is not"
-                          " captured in the main config file: '{}'.".
-                          format(attribute_name, self.simdd_json_file[0],
-                                 self.sim_xmi_file[0]))
+            self.assertIn(
+                attribute_name,
+                xmi_parser_attributes,
+                "The attribute '{}' specified in the file: '{}' is not"
+                " captured in the main config file: '{}'.".format(
+                    attribute_name, self.simdd_json_file[0], self.sim_xmi_file[0]
+                ),
+            )
 
     def test_source_data_commands(self):
         """Testing command information from data files.
@@ -537,22 +668,27 @@ class test_SourceSimulatorInfo(unittest.TestCase):
         information captured in the XMI file generated using POGO.
 
         """
-        xmi_parser_commands = (
-            self.xmi_parser.get_device_command_metadata())
-        simdd_parser_commands = (
-            self.simdd_parser.get_device_command_metadata())
+        xmi_parser_commands = self.xmi_parser.get_device_command_metadata()
+        simdd_parser_commands = self.simdd_parser.get_device_command_metadata()
 
         for command_name in MKAT_VDS_COMMAND_LIST:
-            self.assertIn(command_name, xmi_parser_commands,
-                          "The command '{}' is missing from the file: '{}'.".
-                          format(command_name, self.sim_xmi_file[0]))
+            self.assertIn(
+                command_name,
+                xmi_parser_commands,
+                "The command '{}' is missing from the file: '{}'.".format(
+                    command_name, self.sim_xmi_file[0]
+                ),
+            )
 
         for command_name in simdd_parser_commands:
-            self.assertIn(command_name, xmi_parser_commands,
-                          "The command '{}' specified in the file: '{}' is not captured"
-                          "in the main config file: '{}'.".format(
-                              command_name, self.simdd_json_file[0],
-                              self.sim_xmi_file[0]))
+            self.assertIn(
+                command_name,
+                xmi_parser_commands,
+                "The command '{}' specified in the file: '{}' is not captured"
+                "in the main config file: '{}'.".format(
+                    command_name, self.simdd_json_file[0], self.sim_xmi_file[0]
+                ),
+            )
 
     def test_source_data_device_properties(self):
         """Testing device properties information from data files.
@@ -561,59 +697,81 @@ class test_SourceSimulatorInfo(unittest.TestCase):
         information captured in the XMI file generated using POGO.
 
         """
-        xmi_parser_properties = (
-            self.xmi_parser.get_device_properties_metadata('deviceProperties'))
-        simdd_parser_properties = (
-            self.simdd_parser.get_device_properties_metadata('deviceProperties'))
+        xmi_parser_properties = self.xmi_parser.get_device_properties_metadata(
+            "deviceProperties"
+        )
+        simdd_parser_properties = self.simdd_parser.get_device_properties_metadata(
+            "deviceProperties"
+        )
 
         for property_name in simdd_parser_properties:
-            self.assertIn(property_name, xmi_parser_properties,
-                         "The property '{}' specified in the file: '{}' is not captured"
-                         " in the main config file: '{}'.".format(
-                         property_name, self.simdd_json_file[0], self.sim_xmi_file[0]))
+            self.assertIn(
+                property_name,
+                xmi_parser_properties,
+                "The property '{}' specified in the file: '{}' is not captured"
+                " in the main config file: '{}'.".format(
+                    property_name, self.simdd_json_file[0], self.sim_xmi_file[0]
+                ),
+            )
 
     def test_source_data_class_properties(self):
         """Testing if the class properties information in the SimDD is consistant with the"
         information captured in the XMI file generated using POGO.
         """
-        xmi_parser_properties = (
-            self.xmi_parser.get_device_properties_metadata('classProperties'))
-        simdd_parser_properties = (
-            self.simdd_parser.get_device_properties_metadata('classProperties'))
+        xmi_parser_properties = self.xmi_parser.get_device_properties_metadata(
+            "classProperties"
+        )
+        simdd_parser_properties = self.simdd_parser.get_device_properties_metadata(
+            "classProperties"
+        )
 
         for property_name in simdd_parser_properties:
-            self.assertIn(property_name, xmi_parser_properties,
-                         "The property '{}' specified in the file: '{}' is not captured"
-                         " in the main config file: '{}'.".format(
-                         property_name, self.simdd_json_file[0], self.sim_xmi_file[0]))
+            self.assertIn(
+                property_name,
+                xmi_parser_properties,
+                "The property '{}' specified in the file: '{}' is not captured"
+                " in the main config file: '{}'.".format(
+                    property_name, self.simdd_json_file[0], self.sim_xmi_file[0]
+                ),
+            )
 
 
-class test_XmiSimddSupplementaryDeviceIntegration(ClassCleanupUnittestMixin,
-                                                  unittest.TestCase):
+class test_XmiSimddSupplementaryDeviceIntegration(
+    ClassCleanupUnittestMixin, unittest.TestCase
+):
     """A test class that tests the use of both the xmi and simdd.
 
     This ensures that the specified parameters in the simdd override that of
     the xmi when a simulator is generated.
 
     """
+
     longMessage = True
 
     @classmethod
     def setUpClassWithCleanup(cls):
-        cls.tango_db = cleanup_tempfile(cls, prefix='tango', suffix='.db')
+        cls.tango_db = cleanup_tempfile(cls, prefix="tango", suffix=".db")
         cls.data_descr_files = []
-        cls.data_descr_files.append(pkg_resources.resource_filename(
-            'tango_simlib.tests.config_files', 'Weather.xmi'))
-        cls.data_descr_files.append(pkg_resources.resource_filename(
-            'tango_simlib.tests.config_files', 'Weather_SimDD_2.json'))
-        cls.device_name = 'test/nodb/tangodeviceserver'
+        cls.data_descr_files.append(
+            pkg_resources.resource_filename(
+                "tango_simlib.tests.config_files", "Weather.xmi"
+            )
+        )
+        cls.data_descr_files.append(
+            pkg_resources.resource_filename(
+                "tango_simlib.tests.config_files", "Weather_SimDD_2.json"
+            )
+        )
+        cls.device_name = "test/nodb/tangodeviceserver"
         model = tango_sim_generator.configure_device_models(
-            cls.data_descr_files, cls.device_name)
+            cls.data_descr_files, cls.device_name
+        )
         cls.TangoDeviceServer = tango_sim_generator.get_tango_device_server(
-            model, cls.data_descr_files)[0]
-        cls.tango_context = DeviceTestContext(cls.TangoDeviceServer,
-                                              device_name=cls.device_name,
-                                              db=cls.tango_db)
+            model, cls.data_descr_files
+        )[0]
+        cls.tango_context = DeviceTestContext(
+            cls.TangoDeviceServer, device_name=cls.device_name, db=cls.tango_db
+        )
         start_thread_with_cleanup(cls, cls.tango_context)
 
     def setUp(self):
@@ -629,52 +787,58 @@ class test_XmiSimddSupplementaryDeviceIntegration(ClassCleanupUnittestMixin,
         those of the simdd override the ones in xmi in the configured model
 
         """
-        attr_with_overrriden_info = 'temperature'
+        attr_with_overrriden_info = "temperature"
         simdd_specified_temperature_attr_params = {
-                'description': 'Current actual '
-                'temperature outside near the telescope.',
-                'min_value': '-15', 'max_value': '55'}
+            "description": "Current actual " "temperature outside near the telescope.",
+            "min_value": "-15",
+            "max_value": "55",
+        }
         for data_file in self.data_descr_files:
-            if '.xmi' in data_file.lower():
+            if ".xmi" in data_file.lower():
                 xmi_parser = sim_xmi_parser.XmiParser()
                 xmi_parser.parse(data_file)
-        expected_device_attr_xmi_info = (
-                xmi_parser.get_device_attribute_metadata())
+        expected_device_attr_xmi_info = xmi_parser.get_device_attribute_metadata()
         expected_device_temperature_attr_overridden_info = dict(
-                expected_device_attr_xmi_info[attr_with_overrriden_info],
-                **simdd_specified_temperature_attr_params)
+            expected_device_attr_xmi_info[attr_with_overrriden_info],
+            **simdd_specified_temperature_attr_params
+        )
         # Creating a copy of the attribute info as specified in the xmi and
         # overriding it with that specified in the simdd then create a
         # structure of what is expected as a result of the combination of the two.
         expected_device_attr_xmi_info_copy = expected_device_attr_xmi_info.copy()
-        expected_device_attr_xmi_info_copy[attr_with_overrriden_info] = (
-                expected_device_temperature_attr_overridden_info)
-        expected_device_attr_xmi_overridden = (
-                expected_device_attr_xmi_info_copy)
+        expected_device_attr_xmi_info_copy[
+            attr_with_overrriden_info
+        ] = expected_device_temperature_attr_overridden_info
+        expected_device_attr_xmi_overridden = expected_device_attr_xmi_info_copy
         sim_quantities = self.instance.model.sim_quantities
         for expected_quantity in expected_device_attr_xmi_info.keys():
-            self.assertIn(expected_quantity, sim_quantities,
-                          "The attribute {} is not in the parsed "
-                          "attribute list".format(expected_quantity))
+            self.assertIn(
+                expected_quantity,
+                sim_quantities,
+                "The attribute {} is not in the parsed "
+                "attribute list".format(expected_quantity),
+            )
             actual_device_attr_info = sim_quantities[expected_quantity].meta
             for prop in expected_device_attr_xmi_info[expected_quantity]:
                 # The 'inherited' parameter is not part of the Tango device attribute
                 # properties.
-                if prop == 'inherited':
+                if prop == "inherited":
                     continue
                 if prop not in simdd_specified_temperature_attr_params.keys():
                     self.assertEquals(
-                            expected_device_attr_xmi_info[expected_quantity][prop],
-                            actual_device_attr_info[prop],
-                            "The {} quantity expected value for the parameter "
-                            "'{}' does not match with the actual value in the "
-                            "device model".format(expected_quantity, prop))
-                self.assertEquals(
-                        expected_device_attr_xmi_overridden[expected_quantity][prop],
+                        expected_device_attr_xmi_info[expected_quantity][prop],
                         actual_device_attr_info[prop],
-                        "The {} quantity expected value for the overridden "
-                        "parameter '{}' does not match with the actual value "
-                        "in the device model".format(expected_quantity, prop))
+                        "The {} quantity expected value for the parameter "
+                        "'{}' does not match with the actual value in the "
+                        "device model".format(expected_quantity, prop),
+                    )
+                self.assertEquals(
+                    expected_device_attr_xmi_overridden[expected_quantity][prop],
+                    actual_device_attr_info[prop],
+                    "The {} quantity expected value for the overridden "
+                    "parameter '{}' does not match with the actual value "
+                    "in the device model".format(expected_quantity, prop),
+                )
 
     def test_xmi_simdd_command_parameters_when_both_specified(self):
         """Testing command parameters when both xmi and simdd are specified.
@@ -684,48 +848,55 @@ class test_XmiSimddSupplementaryDeviceIntegration(ClassCleanupUnittestMixin,
         those of the simdd override the ones in xmi in the configured model
 
         """
-        cmd_with_overrriden_info = 'On'
-        simdd_specified_on_cmd_params = {'doc_in': 'No input parameter required',
-                                         'doc_out': 'Command responds only'}
+        cmd_with_overrriden_info = "On"
+        simdd_specified_on_cmd_params = {
+            "doc_in": "No input parameter required",
+            "doc_out": "Command responds only",
+        }
         for data_file in self.data_descr_files:
-            if '.xmi' in data_file.lower():
+            if ".xmi" in data_file.lower():
                 xmi_parser = sim_xmi_parser.XmiParser()
                 xmi_parser.parse(data_file)
-        expected_device_cmd_xmi_info = (
-                xmi_parser.get_device_command_metadata())
+        expected_device_cmd_xmi_info = xmi_parser.get_device_command_metadata()
         expected_device_on_cmd_overridden_info = dict(
-                expected_device_cmd_xmi_info[cmd_with_overrriden_info],
-                **simdd_specified_on_cmd_params)
+            expected_device_cmd_xmi_info[cmd_with_overrriden_info],
+            **simdd_specified_on_cmd_params
+        )
         # Creating a copy of the command info as specified in the xmi and
         # overriding it with that specified in the simdd then create a
         # structure of what is expected as a result of the combination of the two.
         expected_device_cmd_xmi_info_copy = expected_device_cmd_xmi_info.copy()
-        expected_device_cmd_xmi_info_copy[cmd_with_overrriden_info] = (
-                expected_device_on_cmd_overridden_info)
-        expected_device_cmd_xmi_overridden = (
-                expected_device_cmd_xmi_info_copy)
+        expected_device_cmd_xmi_info_copy[
+            cmd_with_overrriden_info
+        ] = expected_device_on_cmd_overridden_info
+        expected_device_cmd_xmi_overridden = expected_device_cmd_xmi_info_copy
         sim_actions = self.instance.model.sim_actions_meta
         for expected_action in expected_device_cmd_xmi_info.keys():
             if expected_action not in helper_module.DEFAULT_TANGO_DEVICE_COMMANDS:
-                self.assertIn(expected_action, sim_actions.keys(),
-                              "The command {} is not in the parsed "
-                              "command list".format(expected_action))
+                self.assertIn(
+                    expected_action,
+                    sim_actions.keys(),
+                    "The command {} is not in the parsed "
+                    "command list".format(expected_action),
+                )
                 actual_device_attr_info = sim_actions[expected_action]
                 for prop in expected_device_cmd_xmi_info[expected_action]:
                     # The 'inherited' parameter is not part of the Tango device attribute
                     # properties.
-                    if prop == 'inherited':
+                    if prop == "inherited":
                         continue
                     if prop not in simdd_specified_on_cmd_params.keys():
                         self.assertEquals(
-                                expected_device_cmd_xmi_info[expected_action][prop],
-                                actual_device_attr_info[prop],
-                                "The {} action expected value for the parameter "
-                                "'{}' does not match with the actual value in the "
-                                "device model".format(expected_action, prop))
-                    self.assertEquals(
-                            expected_device_cmd_xmi_overridden[expected_action][prop],
+                            expected_device_cmd_xmi_info[expected_action][prop],
                             actual_device_attr_info[prop],
-                            "The {} action expected value for the overridden "
-                            "parameter '{}' does not match with the actual value "
-                            "in the device model".format(expected_action, prop))
+                            "The {} action expected value for the parameter "
+                            "'{}' does not match with the actual value in the "
+                            "device model".format(expected_action, prop),
+                        )
+                    self.assertEquals(
+                        expected_device_cmd_xmi_overridden[expected_action][prop],
+                        actual_device_attr_info[prop],
+                        "The {} action expected value for the overridden "
+                        "parameter '{}' does not match with the actual value "
+                        "in the device model".format(expected_action, prop),
+                    )

--- a/tango_simlib/tests/test_tango_sim_generator.py
+++ b/tango_simlib/tests/test_tango_sim_generator.py
@@ -6,6 +6,9 @@
 #########################################################################################
 """This module tests the tango_sim_generator on the xmi and fangodango files in config
 """
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import time
 import logging
 import unittest

--- a/tango_simlib/utilities/base_parser.py
+++ b/tango_simlib/utilities/base_parser.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 ######################################################################################### 
 # Copyright 2018 SKA South Africa (http://ska.ac.za/)                                   #
 #                                                                                       #

--- a/tango_simlib/utilities/fandango_json_parser.py
+++ b/tango_simlib/utilities/fandango_json_parser.py
@@ -10,6 +10,9 @@ simulator.
 Instructions on how to create this json file can be found at the link below:
 https://github.com/tango-controls/fandango/blob/master/doc/recipes/ExportDeviceData.rst
 """
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 
 import logging
 import json

--- a/tango_simlib/utilities/helper_module.py
+++ b/tango_simlib/utilities/helper_module.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 ######################################################################################### 
 # Copyright 2017 SKA South Africa (http://ska.ac.za/)                                   #
 #                                                                                       #

--- a/tango_simlib/utilities/sim_sdd_xml_parser.py
+++ b/tango_simlib/utilities/sim_sdd_xml_parser.py
@@ -6,6 +6,9 @@
 """This module performs the parsing of the SKA Self-Description Data XML schema
 file generated from the DSL.
 """
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import xml.etree.ElementTree as ET
 
 from tango_simlib.utilities.base_parser import Parser

--- a/tango_simlib/utilities/sim_xmi_parser.py
+++ b/tango_simlib/utilities/sim_xmi_parser.py
@@ -7,6 +7,9 @@
 Simlib library generic simulator generator utility to be used to generate an actual
 TANGO device that exhibits the behaviour defined in the data description file.
 """
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import logging
 
 import xml.etree.ElementTree as ET

--- a/tango_simlib/utilities/simdd_json_parser.py
+++ b/tango_simlib/utilities/simdd_json_parser.py
@@ -6,6 +6,9 @@
 """This module performs the parsing of the Simulator Description Datafile,
 containing the information needed to instantiate a useful device simulator.
 """
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 import logging
 import json
 import pkg_resources

--- a/tango_simlib/utilities/testutils.py
+++ b/tango_simlib/utilities/testutils.py
@@ -1,3 +1,6 @@
+from __future__ import print_function
+from __future__ import division
+from __future__ import absolute_import
 ######################################################################################### 
 # Copyright 2017 SKA South Africa (http://ska.ac.za/)                                   #
 #                                                                                       #
@@ -32,7 +35,7 @@ def cleanup_tempfile(test_instance, unlink=False, *mkstemp_args, **mkstemp_kwarg
     def cleanup():
         try:
             os.unlink(fname)
-        except OSError, e:
+        except OSError as e:
             if e.errno == errno.ENOENT: pass
             else: raise
     test_instance.addCleanup(cleanup)
@@ -50,7 +53,7 @@ def cleanup_tempdir(test_instance, *mkdtemp_args, **mkdtemp_kwargs):
     def cleanup():
         try:
             shutil.rmtree(dirname)
-        except OSError, e:
+        except OSError as e:
             if e.errno == errno.ENOENT: pass
             else: raise
     test_instance.addCleanup(cleanup)

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,87 @@
+[tox]
+envlist = code_autoformat,docs,py_futurize_stage_1,py_futurize_stage_2,py{27,36}
+minversion = 3.8.1
+skip_missing_interpreters = true
+
+[testenv]
+passenv = test_flags
+commands =
+    coverage run --source="{env:test_flags}" -m nose --xunit-file=nosetests_{envname}.xml
+    coverage xml -o coverage_{envname}.xml
+    coverage html
+    coverage report -m --skip-covered
+
+deps =
+    coverage
+    mock
+    nose
+    nosexcover
+
+whitelist_externals =
+    bash
+    curl
+    find
+    grep
+    make
+
+[testenv:code_autoformat]
+basepython = python3.6
+skip_install = True
+description = "This stage will execute black, which will format the whole codebase."
+commands =
+    curl -sL https://www.gitignore.io/api/python,virtualenv > .gitignore
+    black .
+deps =
+    black==19.10b0
+whitelist_externals =
+    {[testenv]whitelist_externals}
+
+[testenv:docs]
+skip_install = True
+description = Generate docs if available
+# whitelisting non-virtualenv commands.
+whitelist_externals =
+    {[testenv]whitelist_externals}
+changedir = doc
+commands = make html
+deps =
+    sphinx>=1.2.3, <2.0
+    docutils>=0.12, <1.0
+    sphinx_rtd_theme>=0.1.5, <1.0
+    numpydoc>=0.5, <1.0
+    sphinx-pypi-upload
+
+[testenv:py_futurize_stage_1]
+skip_install = True
+description = "This will modernize Python 2 code only no compatibility with Python 3"
+toxworkdir = {toxinidir}
+deps =
+    future
+    futures
+    ipython
+commands =
+    bash -c "find . -name '*.py' -type f -print | \
+                grep -v '.tox' | grep -v '.eggs' | \
+                xargs futurize --stage1 --write --all-imports --nobackups"
+whitelist_externals =
+    {[testenv]whitelist_externals}
+
+[testenv:py_futurize_stage_2]
+skip_install = True
+description = "Adds a dependency on future to provide Py3 compatibility including cleanup."
+toxworkdir = {toxinidir}
+deps =
+    {[testenv:py_futurize_stage_1]deps}
+commands =
+    bash -c "find . -name '*.py' -type f -print | \
+                grep -v '.tox' | grep -v '.eggs' | \
+                xargs futurize --stage2 --write --all-imports --nobackups"
+    bash -c "grep --exclude=tox.ini -rl 'from __future__ import unicode_literals' | \
+                xargs sed -e 's/from __future__ import unicode_literals//g' -i"
+    bash -c "grep --exclude=tox.ini -rl 'from builtins import str' | \
+                xargs sed -e 's/from builtins import str//g' -i"
+    bash -c "grep --exclude=tox.ini -rl 'from builtins import *' | \
+                xargs sed -e 's/from builtins import \*//g' -i"
+
+whitelist_externals =
+    {[testenv]whitelist_externals}

--- a/tox.ini
+++ b/tox.ini
@@ -16,6 +16,7 @@ deps =
     mock
     nose
     nosexcover
+    nos
 
 whitelist_externals =
     bash

--- a/tox.ini
+++ b/tox.ini
@@ -4,9 +4,8 @@ minversion = 3.8.1
 skip_missing_interpreters = true
 
 [testenv]
-passenv = test_flags
 commands =
-    coverage run --source="{env:test_flags}" -m nose --xunit-file=nosetests_{envname}.xml
+    coverage run --source="tango_simlib" -m nose --with-xunitmp --xunit-file=nosetests_{envname}.xml
     coverage xml -o coverage_{envname}.xml
     coverage html
     coverage report -m --skip-covered
@@ -16,7 +15,7 @@ deps =
     mock
     nose
     nosexcover
-    nos
+    nose_xunitmp
 
 whitelist_externals =
     bash


### PR DESCRIPTION
This adds Stage 1 Futurize changes to the tango-simlib package as part of the Python 2 to Python 3 migration. 
It also adds a new tox file that is still a WIP. 



- [x] Code meets our [python style guidelines](https://docs.google.com/document/d/1aZoIyR9tz5rCWr2qJKuMTmKp2IzHlFjrCFrpDDHFypM/edit?usp=sharing)?
- [x] Unit tested (coded, passed, included)?
- [x] Requested at least 2 reviewers?

JIRA: [MT-738](https://skaafrica.atlassian.net/browse/MT-738)
