### PR TITLE
fixed rst long_description

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -69,7 +69,7 @@ Installation
 - Installation requires the TANGOBINARY_ prerequisites to be installed.
 
 
-.. code-block:: bash
+:: bash
     sudo apt-get install -y --no-install-recommends $(grep -vE "^\s*#" apt-build-requirements.txt | tr "\n" " ")
 
 

--- a/setup.py
+++ b/setup.py
@@ -11,10 +11,11 @@ files = {"Readme": "README.rst", "Changelog": "CHANGELOG.rst"}
 long_description = ""
 for name, filename in files.items():
     if name != "Readme":
-        long_description += "# {}\n".format(name)
+        header = '='*len(name)
+        long_description += "\n{}\n{}\n{}\n".format(header,name,header)
     with open(os.path.join(this_directory, filename)) as _f:
         file_contents = _f.read()
-    long_description += file_contents + "\n\n"
+    long_description += "\n" + file_contents + "\n\n"
 
 setup(
     name="tango_simlib",

--- a/setup.py
+++ b/setup.py
@@ -11,8 +11,8 @@ files = {"Readme": "README.rst", "Changelog": "CHANGELOG.rst"}
 long_description = ""
 for name, filename in files.items():
     if name != "Readme":
-        header = '='*len(name)
-        long_description += "\n{}\n{}\n{}\n".format(header,name,header)
+        header = "=" * len(name)
+        long_description += "\n{}\n{}\n{}\n".format(header, name, header)
     with open(os.path.join(this_directory, filename)) as _f:
         file_contents = _f.read()
     long_description += "\n" + file_contents + "\n\n"


### PR DESCRIPTION
This fixes the long_description as it uses rst text format and the code in the setup.py had to be fixed when concatenating file contents into one string. 

this can be tested with `python setup.py check -r -s`

- [x] Code meets our [python style guidelines](https://docs.google.com/document/d/1aZoIyR9tz5rCWr2qJKuMTmKp2IzHlFjrCFrpDDHFypM/edit?usp=sharing)?
- [x] Unit tested (coded, passed, included)?
- [x] Requested at least 2 reviewers?
- [x] Made corresponding changes to the documentation (e.g. Python documentation, System Engineering Documentation, version description updates, README file, etc)?

JIRA: [MT-1121](https://skaafrica.atlassian.net/browse/MT-1121)
