### PR TITLE
Prepare for 0.6.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -8,6 +8,15 @@
 .. _115: https://github.com/ska-sa/tango-simlib/pull/115
 .. _116: https://github.com/ska-sa/tango-simlib/pull/116
 .. _117: https://github.com/ska-sa/tango-simlib/pull/117
+.. _118: https://github.com/ska-sa/tango-simlib/pull/118
+.. _119: https://github.com/ska-sa/tango-simlib/pull/119
+
+0.6.0
+-----
+- Updated CHANGELOG in 118_
+- Added `tango-yaml` tool in 119_
+    - This tool translates fandango (fgo), XMI (xmi) or a running Tango device to YAML.
+    - Once installed, run `tango-yaml -h` for details.
 
 0.5.0
 -----
@@ -85,4 +94,4 @@
 -----
 - Handle DevEnum data type TANGO attributes
 - Handle Spectrum data format TANGO attributes
-  
+

--- a/README.rst
+++ b/README.rst
@@ -89,6 +89,31 @@ This package is available on *PYPI*, allowing
 
     $ pip install tango-simlib
 
+Tango-YAML
+----------
+
+After installing tango_simlib, the ``tango-yaml`` script will be available to use
+
+.. code-block:: bash
+
+    $ tango-yaml -h
+
+    usage: tango_yaml [-h] {xmi,fandango,tango_device} ...
+
+    This program translates various file formats that describe Tango devices to
+    YAML
+
+    positional arguments:
+    {xmi,fandango,tango_device}
+                            sub command help
+        xmi                 Build YAML from a XMI file
+        fandango            Build YAML from a fandango file
+        tango_device        Build YAML from a running Tango device
+
+    optional arguments:
+    -h, --help            show this help message and exit
+
+
 Documentation
 -------------
 


### PR DESCRIPTION
Updated CHANGELOG and README for 0.6.0 release.

Latest readthedocs with the new tango-yaml section [here](https://tango-simlib.readthedocs.io/en/latest/intro/#translating-a-tango-device-specification-or-a-running-tango-device-to-yaml)

Passing master build [here](http://ci.camlab.kat.ac.za/job/tango_simlib-multibranch/job/master/)