### PR TITLE
Added ability to do device validation in the `tango-yaml` tool

### DIFF
--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -217,20 +217,22 @@ After installing tango_simlib, the ``tango-yaml`` script will be available to us
 
     $ tango-yaml -h
 
-    usage: tango_yaml [-h] {xmi,fandango,tango_device} ...
+      usage: tango_yaml [-h] {xmi,fandango,tango_device,validate} ...
 
-    This program translates various file formats that describe Tango devices to
-    YAML
+      This program translates various file formats that describe Tango devices to
+      YAML. Or validates the conformance of a device against a specification.
 
-    positional arguments:
-    {xmi,fandango,tango_device}
-                            sub command help
-        xmi                 Build YAML from a XMI file
-        fandango            Build YAML from a fandango file
-        tango_device        Build YAML from a running Tango device
+      positional arguments:
+        {xmi,fandango,tango_device,validate}
+                              sub command help
+          xmi                 Build YAML from a XMI file
+          fandango            Build YAML from a fandango file
+          tango_device        Build YAML from a running Tango device
+          validate            Check conformance of a Tango device against a
+                              specification in YAML format
 
-    optional arguments:
-    -h, --help            show this help message and exit
+      optional arguments:
+        -h, --help            show this help message and exit
 
 XMI
 ---

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -399,3 +399,63 @@ Example
           - name: LoggingLevelDefault
           - name: LoggingTargetsDefault
           ...
+
+
+Validation
+----------
+
+The conformance to a specification can be checked against a Tango device.
+When the optional `-bidirectional` flag is added the differences that are on the device
+and not in the specification are also listed.
+
+.. code-block:: bash
+
+    $ tango-yaml validate -h
+
+      usage: tango_yaml validate [-h] (-url URL | -path PATH) [-bidirectional]
+                                tango_device_name
+
+      positional arguments:
+        tango_device_name  Tango device name in the format domain/family/member.
+                          TANGO_HOST env variable has to be set
+
+      optional arguments:
+        -h, --help         show this help message and exit
+        -url URL           The URL to a YAML specification file
+        -path PATH         The file path to a YAML specification file
+        -bidirectional     When bidirectional is included, any details on the device
+                          that is not in the spec is also listed.
+
+Example
+
+.. code-block:: bash
+
+    $ tango-yaml validate -path ./DishMaster.yaml  mid_d0001/elt/master
+
+      Command differs, [SetDSStandbyFPModeTask] specified but missing in device
+      Command [GetVersionInfo] differs:
+              doc_out:
+                      specification: Uninitialised
+                      device: Version strings
+      Command [GetVersionInfo] differs:
+              dtype_out:
+                      specification: DevString
+                      device: DevVarStringArray
+      Command [Scan] differs:
+              doc_in:
+                      specification: [timestamp]
+                      device: The timestamp indicates the time, in UTC
+      Attribute differs, [loggingLevelElement] specified but missing in device
+      Attribute [adminMode] differs:
+              description:
+                      specification: No description
+                      device: The admin mode reported for this device.
+      Attribute [controlMode] differs:
+              description:
+                      specification: No description
+                      device: The control mode of the device. REMOTE, LOCAL
+      Attribute [versionId] differs:
+              description:
+                      specification: LMC version id (from git tag)
+                      device: Version Id of this device
+      Property [LoggerInitPollPeriod] differs, specified but missing in device

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -345,16 +345,17 @@ Tango device
 
 .. code-block:: bash
 
-    $ tango-yaml tango_device_name -h
+    $ tango-yaml tango_device -h
 
-    usage: tango_yaml tango_device [-h] tango_device_name
+      usage: tango_yaml tango_device [-h] tango_device_name
 
-    positional arguments:
-    tango_device_name  Tango device name in the format domain/family/member.
-                        TANGO_HOST env variable has to be set
+      positional arguments:
+        tango_device_name  Tango device name in the domain/family/member format or
+                          the FQDN
+                          tango://<TANGO_HOST>:<TANGO_PORT>/domain/family/member
 
-    optional arguments:
-    -h, --help         show this help message and exit
+      optional arguments:
+        -h, --help         show this help message and exit
 
 Example
 
@@ -412,25 +413,26 @@ and not in the specification are also listed.
 
     $ tango-yaml validate -h
 
-      usage: tango_yaml validate [-h] (-url URL | -path PATH) [-bidirectional]
+      usage: tango_yaml validate [-h] (--url URL | --path PATH) [--bidirectional]
                                 tango_device_name
 
       positional arguments:
-        tango_device_name  Tango device name in the format domain/family/member.
-                          TANGO_HOST env variable has to be set
+        tango_device_name  Tango device name in the domain/family/member format or
+                          the FQDN
+                          tango://<TANGO_HOST>:<TANGO_PORT>/domain/family/member
 
       optional arguments:
         -h, --help         show this help message and exit
-        -url URL           The URL to a YAML specification file
-        -path PATH         The file path to a YAML specification file
-        -bidirectional     When bidirectional is included, any details on the device
+        --url URL          The URL to a YAML specification file
+        --path PATH        The file path to a YAML specification file
+        --bidirectional    When bidirectional is included, any details on the device
                           that is not in the spec is also listed.
 
 Example
 
 .. code-block:: bash
 
-    $ tango-yaml validate -path ./DishMaster.yaml  mid_d0001/elt/master
+    $ tango-yaml validate --path ./DishMaster.yaml  mid_d0001/elt/master
 
       Command differs, [SetDSStandbyFPModeTask] specified but missing in device
       Command [GetVersionInfo] differs:

--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -407,9 +407,10 @@ Example
 Validation
 ----------
 
-The conformance to a specification can be checked against a Tango device.
-When the optional `-bidirectional` flag is added the differences that are on the device
-and not in the specification are also listed.
+A Tango device's conformance to an interface specification can be checked.
+By default check that the device provides a superset of the specification.
+When the optional `-bidirectional` flag is specified, the check is stricter -
+items on the device interface and not in the specification are also reported.
 
 .. code-block:: bash
 

--- a/tango_simlib/tango_yaml_tools/base.py
+++ b/tango_simlib/tango_yaml_tools/base.py
@@ -116,7 +116,8 @@ class TangoToYAML:
         Parameters
         ----------
         device_name : str
-            Tango device name in the domain/family/member format
+            Tango device name in the domain/family/member format or the
+            FQDN tango://<TANGO_HOST>:<TANGO_PORT>/domain/family/member
         """
         self.parser.parse(device_name)
         return self._build_yaml()

--- a/tango_simlib/tango_yaml_tools/main.py
+++ b/tango_simlib/tango_yaml_tools/main.py
@@ -30,7 +30,7 @@ def _validate_device(args):
     Returns
     -------
     str
-        A string describing the differences or an empty string if it conforms
+        A string indicating whether there are differences or not
     """
     result = ""
     if args.url:
@@ -109,7 +109,7 @@ def main():
 
     validate_parser = subparsers.add_parser(
         "validate",
-        help="Check conformance of a Tango device to specification in YAML format",
+        help="Check conformance of a Tango device against a specification in YAML format",
     )
     validate_parser.add_argument(
         "tango_device_name",

--- a/tango_simlib/tango_yaml_tools/main.py
+++ b/tango_simlib/tango_yaml_tools/main.py
@@ -23,8 +23,6 @@ from tango_simlib.utilities.validate_device import (
 def _validate_device(args):
     """Validate the conformance of a Tango device against a YAML specification
 
-    Exits with code 0 or 1 if it passes or fails respectively.
-
     Parameters
     ----------
     args : argparse.Namespace

--- a/tango_simlib/tango_yaml_tools/main.py
+++ b/tango_simlib/tango_yaml_tools/main.py
@@ -15,8 +15,8 @@ from tango_simlib.utilities.fandango_json_parser import FandangoExportDevicePars
 from tango_simlib.utilities.sim_xmi_parser import XmiParser
 from tango_simlib.utilities.tango_device_parser import TangoDeviceParser
 from tango_simlib.utilities.validate_device import (
-    validate_device_from_url,
     validate_device_from_path,
+    validate_device_from_url,
 )
 
 

--- a/tango_simlib/tango_yaml_tools/main.py
+++ b/tango_simlib/tango_yaml_tools/main.py
@@ -41,7 +41,7 @@ def _validate_device(args):
     if not result:
         source = args.path if args.path else args.url
         result = "No differences between device {} and specification {}".format(
-            args.tango_device, source
+            args.tango_device_name, source
         )
     return result
 

--- a/tango_simlib/tango_yaml_tools/main.py
+++ b/tango_simlib/tango_yaml_tools/main.py
@@ -3,8 +3,8 @@
 #                                                                                       #
 # BSD license - see LICENSE.txt for details                                             #
 #########################################################################################
-"""Entrypoint for the script to parse a Tango file representation or a running device into
-   YAML"""
+"""Entrypoint for the script to parse a Tango file representation or a running device
+   into YAML"""
 from __future__ import absolute_import, division, print_function
 
 import argparse
@@ -34,9 +34,13 @@ def _validate_device(args):
     """
     result = ""
     if args.url:
-        result = validate_device_from_url(args.tango_device_name, args.url)
+        result = validate_device_from_url(
+            args.tango_device_name, args.url, args.bidirectional
+        )
     else:
-        result = validate_device_from_path(args.tango_device_name, args.path)
+        result = validate_device_from_path(
+            args.tango_device_name, args.path, args.bidirectional
+        )
 
     if not result:
         source = args.path if args.path else args.url
@@ -77,8 +81,8 @@ def main():
         prog="tango_yaml",
         description=(
             "This program translates various file formats that "
-            "describe Tango devices to YAML. Or validates the conformance of a device "
-            "against a specification."
+            "describe Tango devices to YAML. Or validates the conformance of a device"
+            " against a specification."
         ),
     )
     subparsers = parser.add_subparsers(help="sub command help")
@@ -109,7 +113,10 @@ def main():
 
     validate_parser = subparsers.add_parser(
         "validate",
-        help="Check conformance of a Tango device against a specification in YAML format",
+        help=(
+            "Check conformance of a Tango device against a specification"
+            " in YAML format"
+        ),
     )
     validate_parser.add_argument(
         "tango_device_name",
@@ -125,6 +132,15 @@ def main():
     )
     source_group.add_argument(
         "-path", type=str, help="The file path to a YAML specification file",
+    )
+
+    validate_parser.add_argument(
+        "-bidirectional",
+        action="store_true",
+        help=(
+            "When bidirectional is included, any details on the "
+            "device that is not in the spec is also listed."
+        ),
     )
 
     args = parser.parse_args()

--- a/tango_simlib/tango_yaml_tools/main.py
+++ b/tango_simlib/tango_yaml_tools/main.py
@@ -13,6 +13,37 @@ from tango_simlib.tango_yaml_tools.base import TangoToYAML
 from tango_simlib.utilities.fandango_json_parser import FandangoExportDeviceParser as FP
 from tango_simlib.utilities.sim_xmi_parser import XmiParser
 from tango_simlib.utilities.tango_device_parser import TangoDeviceParser
+from tango_simlib.utilities.validate_device import (
+    validate_device_from_url,
+    validate_device_from_path,
+)
+
+
+def _validate_device(args):
+    """Validate the conformance of a Tango device against a YAML specification
+
+    Parameters
+    ----------
+    args : argparse.Namespace
+        The parsed arguments
+
+    Returns
+    -------
+    str
+        A string describing the differences or an empty string if it conforms
+    """
+    result = ""
+    if args.url:
+        result = validate_device_from_url(args.tango_device_name, args.url)
+    else:
+        result = validate_device_from_path(args.tango_device_name, args.path)
+
+    if not result:
+        source = args.path if args.path else args.url
+        result = "No differences between device {} and specification {}".format(
+            args.tango_device, source
+        )
+    return result
 
 
 def _build_yaml(args):
@@ -46,7 +77,8 @@ def main():
         prog="tango_yaml",
         description=(
             "This program translates various file formats that "
-            "describe Tango devices to YAML"
+            "describe Tango devices to YAML. Or validates the conformance of a device "
+            "against a specification."
         ),
     )
     subparsers = parser.add_subparsers(help="sub command help")
@@ -75,8 +107,33 @@ def main():
         ),
     )
 
+    validate_parser = subparsers.add_parser(
+        "validate",
+        help="Check conformance of a Tango device to specification in YAML format",
+    )
+    validate_parser.add_argument(
+        "tango_device_name",
+        type=str,
+        help=(
+            "Tango device name in the format domain/family/member. "
+            "TANGO_HOST env variable has to be set"
+        ),
+    )
+    source_group = validate_parser.add_mutually_exclusive_group(required=True)
+    source_group.add_argument(
+        "-url", type=str, help="The URL to a YAML specification file",
+    )
+    source_group.add_argument(
+        "-path", type=str, help="The file path to a YAML specification file",
+    )
+
     args = parser.parse_args()
-    result = _build_yaml(args)
+
+    result = ""
+    if "url" in args:
+        result = _validate_device(args)
+    else:
+        result = _build_yaml(args)
     if result:
         print(result)
     else:

--- a/tango_simlib/tests/config_files/DishMaster.yaml
+++ b/tango_simlib/tests/config_files/DishMaster.yaml
@@ -1,0 +1,2500 @@
+- class: DishMaster
+  meta:
+    attributes:
+    - data_format: SCALAR
+      data_type: DevLong
+      description: Current  logging level to Central logging target for this device
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%d'
+      label: loggingLevelCentral
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: loggingLevelCentral
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: logginglevelcentral
+    - data_format: SCALAR
+      data_type: DevLong
+      description: Current  logging level to Element logging target for this device
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%d'
+      label: loggingLevelElement
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: loggingLevelElement
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: logginglevelelement
+    - data_format: SCALAR
+      data_type: DevLong
+      description: Current  logging level to Syslog for this device
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%d'
+      label: loggingLevelStorage
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: loggingLevelStorage
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: logginglevelstorage
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: 'Central logging target status. Possible values are:
+
+
+        UNKNOWN: Typically set at device startup
+
+        DISABLED: When central logging target is disabled (see device properties)
+
+        OK: When central logging target is initialized with success
+
+        FAILED: When central logging target initialization fails, e.g. logger is offline
+        or proxy name invalid '
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: centralLoggerStatus
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: centralLoggerStatus
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: 'Element logging target status. Possible values are:
+
+
+        UNKNOWN: Typically set at device startup
+
+        DISABLED: When element logging target is disabled (see device properties)
+
+        OK: When element logging target is initialized with success
+
+        FAILED: When element logging target initialization fails, e.g. logger is offline
+        or proxy name invalid '
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: elementLoggerStatus
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: elementLoggerStatus
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: 'Storage logging target status. Possible values are:
+
+
+        UNKNOWN: Typically set at device startup
+
+        DISABLED: When storage logging target is disabled (see device properties)
+
+        OK: When storage logging target is initialized with success
+
+        FAILED: When storage logging target initialization fails, e.g. logger is offline
+        or proxy name invalid '
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: storageLoggerStatus
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: storageLoggerStatus
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevBoolean
+      description: 'Enable/disable the central logger in device.
+
+        NB: Attribute is not persisted after device restart.'
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: Not specified
+      label: centralLoggerEnabled
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: centralLoggerEnabled
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: centralloggerenabled
+    - data_format: SCALAR
+      data_type: DevBoolean
+      description: 'Enable/disable the central logger in device.
+
+        NB: Attribute is not persisted after device restart.'
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: Not specified
+      label: elementLoggerEnabled
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: elementLoggerEnabled
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: elementloggerenabled
+    - data_format: SCALAR
+      data_type: DevBoolean
+      description: 'Enable/disable the storage logger in device.
+
+        NB: Attribute is not persisted after device restart.'
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: Not specified
+      label: storageLoggerEnabled
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: storageLoggerEnabled
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: storageloggerenabled
+    - data_format: SCALAR
+      data_type: DevString
+      description: Current Central logging target
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: loggingTargetCentral
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: loggingTargetCentral
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: loggingtargetcentral
+    - data_format: SCALAR
+      data_type: DevString
+      description: Current Element logging target
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: loggingTargetElement
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: loggingTargetElement
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: loggingtargetelement
+    - data_format: SCALAR
+      data_type: DevString
+      description: Current storage logging target
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: loggingTargetStorage
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: loggingTargetStorage
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: loggingtargetstorage
+    - data_format: SCALAR
+      data_type: DevFloat
+      description: Rate of events received from the device in Hz.
+      disp_level: OPERATOR
+      display_unit: Hz
+      format: '%6.2f'
+      label: eventRate
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: eventRate
+      standard_unit: Hz
+      unit: Hz
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevString
+      description: LMC version id (from git tag)
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: versionId
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: versionId
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevString
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: revisionId
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: revisionId
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: dishMode
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: dishMode
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: dishmode
+    - data_format: SCALAR
+      data_type: DevState
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: Not specified
+      label: dishState
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: dishState
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: powerState
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: powerState
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: observingState
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: observingState
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: elementType
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: elementType
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: adminMode
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: adminMode
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: adminmode
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: healthState
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: healthState
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: healthstate
+    - data_format: SCALAR
+      data_type: DevBoolean
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: Not specified
+      label: simulationMode
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: simulationMode
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevBoolean
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: Not specified
+      label: testMode
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: testMode
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: testmode
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: b1CapabilityState
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: b1CapabilityState
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: b2CapabilityState
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: b2CapabilityState
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: b3CapabilityState
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: b3CapabilityState
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: b4CapabilityState
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: b4CapabilityState
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: b5aCapabilityState
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: b5aCapabilityState
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: b5bCapabilityState
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: b5bCapabilityState
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: requestedBand
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: requestedBand
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: requestedband
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: configuredBand
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: configuredBand
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: No description
+      disp_level: EXPERT
+      display_unit: No display unit
+      format: '%s'
+      label: seCtrlPowerStatus
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: seCtrlPowerStatus
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: controlMode
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: controlMode
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: controlmode
+    - data_format: SCALAR
+      data_type: DevBoolean
+      description: Enable/disable handling of band error event
+      disp_level: EXPERT
+      display_unit: No display unit
+      format: Not specified
+      label: enableBandErrorEventHandler
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: enableBandErrorEventHandler
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: enablebanderroreventhandler
+    - data_format: SCALAR
+      data_type: DevBoolean
+      description: Enable/disable handling of ESTOP event
+      disp_level: EXPERT
+      display_unit: No display unit
+      format: Not specified
+      label: enableESTOPEventHandler
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: enableESTOPEventHandler
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: enableestopeventhandler
+    - data_format: SCALAR
+      data_type: DevBoolean
+      description: Enable/disable handling of power cut event
+      disp_level: EXPERT
+      display_unit: No display unit
+      format: Not specified
+      label: enablePowerCutEventHandler
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: enablePowerCutEventHandler
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: enablepowercuteventhandler
+    - data_format: SCALAR
+      data_type: DevBoolean
+      description: No description
+      disp_level: EXPERT
+      display_unit: No display unit
+      format: Not specified
+      label: enablePowerRestoreEventHandler
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: enablePowerRestoreEventHandler
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: enablepowerrestoreeventhandler
+    - data_format: SCALAR
+      data_type: DevBoolean
+      description: No description
+      disp_level: EXPERT
+      display_unit: No display unit
+      format: Not specified
+      label: enableBandInFocusEventHandler
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: enableBandInFocusEventHandler
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: enablebandinfocuseventhandler
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: Sub-Element run status (0=UNKNOWN, 1=ONLINE, 2=SOFT-OFFLINE, 3=HARD-OFFLINE
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: seRunStatus
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: seRunStatus
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevString
+      description: Set device proxy address of TM device to be monitored
+      disp_level: EXPERT
+      display_unit: No display unit
+      format: '%s'
+      label: tmProxyAddress
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: tmProxyAddress
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: tmproxyaddress
+    - data_format: SCALAR
+      data_type: DevBoolean
+      description: Enable/disable handling of TM proxy monitoring handler
+      disp_level: EXPERT
+      display_unit: No display unit
+      format: Not specified
+      label: enableTMProxyMoniHandler
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: enableTMProxyMoniHandler
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: enabletmproxymonihandler
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: usageStatus
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: usageStatus
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: elementLogLevel
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: elementLogLevel
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: centralLogLevel
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: centralLogLevel
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: storageLogLevel
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: storageLogLevel
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevDouble
+      description: "Configures the Max Short Term Average Power (5sec?10min) in kilowatt\
+        \ that the \nDSH instance is curtailed to while dshPowerCurtailment is [TRUE].\
+        \ \nThe default value is 13.5. "
+      disp_level: OPERATOR
+      display_unit: kW
+      format: '%6.2f'
+      label: dshMaxShortTermPower
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: '20'
+      min_alarm: Not specified
+      min_value: '12.5'
+      name: dshMaxShortTermPower
+      standard_unit: kW
+      unit: kW
+      writable: READ_WRITE
+      writable_attr_name: dshmaxshorttermpower
+    - data_format: SCALAR
+      data_type: DevBoolean
+      description: "The Max Short Term Average Power (5sec?10min) of each DSH instance\
+        \ is curtailed \nto the value configured in dshMaxShortTermPower.  \nThe default\
+        \ condition is [TRUE] ? power curtailment is on.  \nWith power curtailment\
+        \ [TRUE], all DSH functionality is available but at reduced \nperformance\
+        \ (for example reduced slew rates). \nWith power curtailment [FALSE], all\
+        \ DSH functionality is available at full performance \n(for example maximum\
+        \ slew rates). "
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: Not specified
+      label: dshPowerCurtailment
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: dshPowerCurtailment
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: dshpowercurtailment
+    - data_format: SCALAR
+      data_type: DevEnum
+      description: 'Do not set this as forwarded attr and event otherwise you cannot
+        read event (DeviceAttribute
+
+        returning FMT_UNKNOWN as attr format). This is probably a Tango bug.'
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: pointingState
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: pointingState
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: setStowModeProgress
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: setStowModeProgress
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: setstowmodeprogress
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: setStandbyLPModeProgress
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: setStandbyLPModeProgress
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: setstandbylpmodeprogress
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: setStandbyFPModeProgress
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: setStandbyFPModeProgress
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: setstandbyfpmodeprogress
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: setMaintenanceModeProgress
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: setMaintenanceModeProgress
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: setmaintenancemodeprogress
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: setOperateModeProgress
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: setOperateModeProgress
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: setoperatemodeprogress
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: configureBandProgress
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: configureBandProgress
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ_WRITE
+      writable_attr_name: configurebandprogress
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: SPF set standby LP mode status progress
+      disp_level: EXPERT
+      display_unit: No display unit
+      format: '%s'
+      label: spfSetStandbyLPModeProgress
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: spfSetStandbyLPModeProgress
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: No description
+      disp_level: EXPERT
+      display_unit: No display unit
+      format: '%s'
+      label: dsSetStandbyLPModeProgress
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: dsSetStandbyLPModeProgress
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: No description
+      disp_level: EXPERT
+      display_unit: No display unit
+      format: '%s'
+      label: spfSetOperateModeProgress
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: spfSetOperateModeProgress
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: No description
+      disp_level: EXPERT
+      display_unit: No display unit
+      format: '%s'
+      label: dsSetStandbyFPModeProgress
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: dsSetStandbyFPModeProgress
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: No description
+      disp_level: EXPERT
+      display_unit: No display unit
+      format: '%s'
+      label: dsSetPointModeProgress
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: dsSetPointModeProgress
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: No description
+      disp_level: EXPERT
+      display_unit: No display unit
+      format: '%s'
+      label: dsIndexingProgress
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: dsIndexingProgress
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: No description
+      disp_level: EXPERT
+      display_unit: No display unit
+      format: '%s'
+      label: spfSetMaintenanceModeProgress
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: spfSetMaintenanceModeProgress
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: No description
+      disp_level: EXPERT
+      display_unit: No display unit
+      format: '%s'
+      label: dsStowProgress
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: dsStowProgress
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: setStandbyFPOnBandErrorProgress
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: setStandbyFPOnBandErrorProgress
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: setStandbyFPOnESTOPProgress
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: setStandbyFPOnESTOPProgress
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: shutdownOnPowerCutProgress
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: shutdownOnPowerCutProgress
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: startupOnPowerRestoreProgress
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: startupOnPowerRestoreProgress
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: No description
+      disp_level: EXPERT
+      display_unit: No display unit
+      format: '%s'
+      label: dsManagerRunStatus
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: dsManagerRunStatus
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: No description
+      disp_level: EXPERT
+      display_unit: No display unit
+      format: '%s'
+      label: spfControllerRunStatus
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: spfControllerRunStatus
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: No description
+      disp_level: EXPERT
+      display_unit: No display unit
+      format: '%s'
+      label: rxControllerRunStatus
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: rxControllerRunStatus
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: No description
+      disp_level: EXPERT
+      display_unit: No display unit
+      format: '%s'
+      label: spfGoOperationalProgress
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: spfGoOperationalProgress
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SPECTRUM
+      data_type: DevString
+      description: No description
+      disp_level: EXPERT
+      display_unit: No display unit
+      format: '%s'
+      label: tmProxyRunStatus
+      max_alarm: Not specified
+      max_dim_x: 2
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: tmProxyRunStatus
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevState
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: Not specified
+      label: State
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: State
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    - data_format: SCALAR
+      data_type: DevString
+      description: No description
+      disp_level: OPERATOR
+      display_unit: No display unit
+      format: '%s'
+      label: Status
+      max_alarm: Not specified
+      max_dim_x: 1
+      max_dim_y: 0
+      max_value: Not specified
+      min_alarm: Not specified
+      min_value: Not specified
+      name: Status
+      standard_unit: No standard unit
+      unit: ''
+      writable: READ
+      writable_attr_name: None
+    commands:
+    - disp_level: OPERATOR
+      doc_in: ON/OFF
+      doc_out: Uninitialised
+      dtype_in: DevBoolean
+      dtype_out: DevVoid
+      name: Capture
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: ClearOldTasks
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: ClearTaskHistory
+    - disp_level: OPERATOR
+      doc_in: Band id {1=B1,2=B2,3=B3,4=B4,5=B5a,6=B5b}
+      doc_out: Uninitialised
+      dtype_in: DevShort
+      dtype_out: DevVoid
+      name: ConfigureAndSynchroniseRxBand
+    - disp_level: OPERATOR
+      doc_in: '[timestamp]'
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: ConfigureBand1
+    - disp_level: OPERATOR
+      doc_in: '[timestamp]'
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: ConfigureBand2
+    - disp_level: OPERATOR
+      doc_in: '[timestamp]'
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: ConfigureBand3
+    - disp_level: OPERATOR
+      doc_in: '[timestamp]'
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: ConfigureBand4
+    - disp_level: OPERATOR
+      doc_in: '[timestamp]'
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: ConfigureBand5a
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: ConfigureBand5b
+    - disp_level: OPERATOR
+      doc_in: Attenuation par in DB
+      doc_out: Uninitialised
+      dtype_in: DevFloat
+      dtype_out: DevVoid
+      name: ConfigureRxAttenuation
+    - disp_level: OPERATOR
+      doc_in: Band id
+      doc_out: Uninitialised
+      dtype_in: DevShort
+      dtype_out: DevVoid
+      name: ConfigureRxBand
+    - disp_level: EXPERT
+      doc_in: Task encoded data
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: ConfigureRxBandTask
+    - disp_level: OPERATOR
+      doc_in: enable/disable
+      doc_out: Uninitialised
+      dtype_in: DevBoolean
+      dtype_out: DevVoid
+      name: EnableRxEngineeringMode
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: FlushCommandQueue
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: FlushTaskQueue
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVarLongStringArray
+      name: GetLogAppenderInfo
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevLong
+      name: GetNFailedTaskSequences
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevLong
+      name: GetNIdleTaskSequences
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: The number of queued tasks
+      dtype_in: DevVoid
+      dtype_out: DevLong
+      name: GetNQueuedTasks
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: The number of running task sequences
+      dtype_in: DevVoid
+      dtype_out: DevLong
+      name: GetNRunningTaskSequences
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Number of tasks
+      dtype_in: DevVoid
+      dtype_out: DevLong
+      name: GetNTaskSequences
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVarStringArray
+      name: GetQueuedTaskInfo
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVarStringArray
+      name: GetRegisteredEventHandlers
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVarStringArray
+      name: GetRegisteredEvents
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVarStringArray
+      name: GetRegisteredProxies
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVarStringArray
+      name: GetTaskSequenceInfo
+    - disp_level: EXPERT
+      doc_in: 'Task sequence name.
+
+        If empty returns all task sequences'
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVarStringArray
+      name: GetTaskSequenceSummary
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevString
+      name: GetVersionInfo
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleBandFunctionalErrorEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleBandInFocusEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleDSHealthStateEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleDSIndexerPositionEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleDSIndexingProgressEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleDSInterfaceTypeEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleDSModeEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleDSPointProgressEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleDSPointingStateEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleDSPowerStateEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleDSStandbyFPProgressEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleDSStandbyLPProgressEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleDSStowProgressEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleEStopEvent
+    - disp_level: EXPERT
+      doc_in: Task encoded string including event data
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandlePowerCutEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandlePowerRestoreEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleRxB1CapabilityStateEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleRxB2CapabilityStateEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleRxB3CapabilityStateEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleRxB4CapabilityStateEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleRxB5aCapabilityStateEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleRxB5bCapabilityStateEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleRxConfiguredBandEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleRxEngModeEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleRxHealthStateEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleRxInterfaceTypeEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleRxModeEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleRxPowerStateEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleSPFB1CapabilityStateEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleSPFB2CapabilityStateEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleSPFB3CapabilityStateEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleSPFB4CapabilityStateEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleSPFB5CapabilityStateEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleSPFCOutletStateEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleSPFHealthStateEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleSPFInterfaceTypeEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleSPFMaintenanceProgressEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleSPFModeEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleSPFOperateProgressEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleSPFPowerStateEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleSPFRxOutletStateEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: HandleSPFStandbyLPProgressEvent
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: HandleTMCommLossEvent
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: Init
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: InitializeDevProxies
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: InitializeLoggers
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: The task quota flag
+      dtype_in: DevVoid
+      dtype_out: DevBoolean
+      name: IsTaskQuotaReached
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: MonitorProxies
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerCyclingDDBH
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerCyclingLMC
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerCyclingNSDN
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerCyclingRXPU
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerCyclingSPFC
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerCyclingSTFRRx
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerCyclingSTFRWR
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerCyclingSpare
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerOffDDBH
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerOffLMC
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerOffNSDN
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerOffRXPU
+    - disp_level: EXPERT
+      doc_in: Task encoded data
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: PowerOffRXPUTask
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerOffSPFC
+    - disp_level: EXPERT
+      doc_in: Encoded task data
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: PowerOffSPFCTask
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerOffSTFRRx
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerOffSTFRWR
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerOffSpare
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerOnDDBH
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerOnLMC
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerOnNSDN
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerOnRXPU
+    - disp_level: EXPERT
+      doc_in: Task encoded data
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: PowerOnRXPUTask
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerOnSPFC
+    - disp_level: EXPERT
+      doc_in: Task encoded data
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: PowerOnSPFCTask
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerOnSTFRRx
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerOnSTFRWR
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: PowerOnSpare
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: ResetDishMode
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: ResetDishTasks
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: ResetTrackTable
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: ResetTrackTableBuffer
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: RestartSPFComponents
+    - disp_level: EXPERT
+      doc_in: Name of task to be canceled
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: RevokeTask
+    - disp_level: EXPERT
+      doc_in: Name of task sequence to be revoked.
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: RevokeTaskSequence
+    - disp_level: OPERATOR
+      doc_in: '[timestamp]'
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: Scan
+    - disp_level: OPERATOR
+      doc_in: '[0]: mcBand
+
+        [1]: feedCommand {0=REGENERATE,1=CLEAR-ERRORS}'
+      doc_out: Uninitialised
+      dtype_in: DevVarShortArray
+      dtype_out: DevVoid
+      name: SendSPFFeedCommand
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: SetDSMaintenanceMode
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: SetDSMaintenanceModeTask
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVarLongStringArray
+      name: SetDSPointMode
+    - disp_level: EXPERT
+      doc_in: Task encoded data
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: SetDSPointModeTask
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVarLongStringArray
+      name: SetDSStandbyFPMode
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: SetDSStandbyFPModeTask
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVarLongStringArray
+      name: SetDSStandbyLPMode
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: SetDSStandbyLPModeTask
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVarLongStringArray
+      name: SetDSStowMode
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: SetDSStowModeTask
+    - disp_level: OPERATOR
+      doc_in: bandId position
+      doc_out: Uninitialised
+      dtype_in: DevShort
+      dtype_out: DevVoid
+      name: SetIndexerPosition
+    - disp_level: EXPERT
+      doc_in: Task encoded data
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: SetIndexerPositionTask
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: '== Long field ==
+
+        [0]: ack code (0=OK, 1=QUEUED, 2=FAILED)
+
+
+        == String field ==
+
+        [0]: Informative message or error/fault description'
+      dtype_in: DevVoid
+      dtype_out: DevVarLongStringArray
+      name: SetMaintenanceMode
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: '0]: ack code (0=OK, 1=QUEUED, 2=FAILED)
+
+
+        == String field ==
+
+        [0]: Informative message or error/fault description'
+      dtype_in: DevVoid
+      dtype_out: DevVarLongStringArray
+      name: SetOperateMode
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: SetRxMaintenanceMode
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: SetRxMaintenanceModeTask
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: SetRxStandbyFPMode
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: SetRxStandbyFPModeTask
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: SetRxStandbyLPMode
+    - disp_level: EXPERT
+      doc_in: Task encoded data
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: SetRxStandbyLPModeTask
+    - disp_level: OPERATOR
+      doc_in: Band id
+      doc_out: Uninitialised
+      dtype_in: DevShort
+      dtype_out: DevVoid
+      name: SetSPFBandInFocus
+    - disp_level: EXPERT
+      doc_in: Encoded task data
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: SetSPFBandInFocusTask
+    - disp_level: OPERATOR
+      doc_in: '[0]: bandId [1-5]
+
+        [1]: mode
+
+
+        Allowed modes are:
+
+
+        0= STANDBY-LP
+
+        1= OPERATE
+
+        2= MAINTENANCE'
+      doc_out: Uninitialised
+      dtype_in: DevVarShortArray
+      dtype_out: DevVarLongStringArray
+      name: SetSPFFeedMode
+    - disp_level: OPERATOR
+      doc_in: "bandId: [1-5]\n\nIf bandId=-1 turns on all bands\nIf bandId=0 turns\
+        \ on only active band. \nIf no band is active (was not configured) an exception\
+        \ \nis thrown."
+      doc_out: Uninitialised
+      dtype_in: DevShort
+      dtype_out: DevVoid
+      name: SetSPFLnaPowerOff
+    - disp_level: EXPERT
+      doc_in: Task encoded data
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: SetSPFLnaPowerOffTask
+    - disp_level: OPERATOR
+      doc_in: "bandId: [1-5]\n\nIf bandId=-1 turns on all bands\nIf bandId=0 turns\
+        \ on only active band. \nIf no band is active (was not configured) an exception\
+        \ \nis thrown."
+      doc_out: Uninitialised
+      dtype_in: DevShort
+      dtype_out: DevVoid
+      name: SetSPFLnaPowerOn
+    - disp_level: EXPERT
+      doc_in: Task encoded data
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: SetSPFLnaPowerOnTask
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVarLongStringArray
+      name: SetSPFMaintenanceMode
+    - disp_level: EXPERT
+      doc_in: Task encoded data
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: SetSPFMaintenanceModeTask
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: '== Long field ==
+
+        [0]: ack code (0=OK, 1=QUEUED, 2=FAILED)
+
+
+        == String field ==
+
+        [0]: Informative message or error/fault description'
+      dtype_in: DevVoid
+      dtype_out: DevVarLongStringArray
+      name: SetSPFOperateMode
+    - disp_level: EXPERT
+      doc_in: Task encoded data
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: SetSPFOperateModeTask
+    - disp_level: OPERATOR
+      doc_in: 'Band id
+
+
+        - bandId=-1 all bands
+
+        - bandId=0 active band
+
+        - band=[1-5] selected band'
+      doc_out: '== Long field ==
+
+        [0]: ack code (0=OK, 1=QUEUED, 2=FAILED)
+
+
+        == String field ==
+
+        [0]: Informative message or error/fault description'
+      dtype_in: DevShort
+      dtype_out: DevVarLongStringArray
+      name: SetSPFOperational
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVarLongStringArray
+      name: SetSPFStandbyLPMode
+    - disp_level: EXPERT
+      doc_in: Task encoded data
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: SetSPFStandbyLPModeTask
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVarLongStringArray
+      name: SetStandbyFPMode
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: SetStandbyFPModeOnBandError
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVarLongStringArray
+      name: SetStandbyLPMode
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: '== Long field ==
+
+        [0]: ack code (0=OK, 1=QUEUED, 2=FAILED)
+
+
+        == String field ==
+
+        [0]: Informative message or error/fault description'
+      dtype_in: DevVoid
+      dtype_out: DevVarLongStringArray
+      name: SetStowMode
+    - disp_level: EXPERT
+      doc_in: Name of TM proxy device to be monitored
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: SetTMProxyAddress
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: ShutdownRXPU
+    - disp_level: EXPERT
+      doc_in: Task data
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: ShutdownRXPUTask
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: ShutdownSPFC
+    - disp_level: EXPERT
+      doc_in: Task data
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: ShutdownSPFCTask
+    - disp_level: OPERATOR
+      doc_in: '[0]: Azimuth
+
+        [1]: Elevation'
+      doc_out: Uninitialised
+      dtype_in: DevVarDoubleArray
+      dtype_out: DevVoid
+      name: Slew
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: StartCapture
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: StartRxCaptureTask
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Device state
+      dtype_in: DevVoid
+      dtype_out: DevState
+      name: State
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Device status
+      dtype_in: DevVoid
+      dtype_out: DevString
+      name: Status
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: StopCapture
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: Synchronise
+    - disp_level: EXPERT
+      doc_in: Task encoded data
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: SynchroniseRxBandTask
+    - disp_level: OPERATOR
+      doc_in: "Time when to start tracking\n\nNB: Specified in the ICD TM-Dish Rev\
+        \ 3a but \nIgnored at present"
+      doc_out: Uninitialised
+      dtype_in: DevString
+      dtype_out: DevVoid
+      name: Track
+    - disp_level: OPERATOR
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: TrackStop
+    - disp_level: EXPERT
+      doc_in: Uninitialised
+      doc_out: Uninitialised
+      dtype_in: DevVoid
+      dtype_out: DevVoid
+      name: UpdateProgressAttrs
+    properties:
+    - name: AdminModeDefault
+    - name: AsynchCmdReplyNRetries
+    - name: AsynchCmdReplyTimeout
+    - name: CentralLoggerEnabledDefault
+    - name: ConfigureTaskTimeout
+    - name: ControlModeDefault
+    - name: DefaultTaskTimeout
+    - name: DsManagerAddress
+    - name: ElementAlarmsAddress
+    - name: ElementDatabaseDSAddress
+    - name: ElementLoggerAddress
+    - name: ElementLoggerEnabledDefault
+    - name: ElementTelModelAddress
+    - name: EnableAutoAdminProxyRegistration
+    - name: EnableLoggerInitPolling
+    - name: LoggerInitPollPeriod
+    - name: LoggingLevelCentralDefault
+    - name: LoggingLevelElementDefault
+    - name: LoggingLevelStorageDefault
+    - name: LoggingTargetCentralDefault
+    - name: LoggingTargetElementDefault
+    - name: LoggingTargetStorageDefault
+    - name: MaxQueueableTask
+    - name: MaxTrackableTasks
+    - name: OperateTaskTimeout
+    - name: PduManagerAddress
+    - name: polled_attr
+    - name: polled_cmd
+    - name: ProcessEventsInQueueThread
+    - name: ProxyTimeout
+    - name: RequestedBandDefault
+    - name: RxControllerAddress
+    - name: RxShutdownTimeDelay
+    - name: ShutdownTaskTimeout
+    - name: SkaLevel
+    - name: SpfControllerAddress
+    - name: SPFStartupTimeout
+    - name: StandbyFPTaskTimeout
+    - name: StorageLoggerEnabledDefault
+    - name: StowTaskTimeout
+    - name: SynchCmdReplyTimeout
+    - name: SyslogFacility
+    - name: SyslogHost
+    - name: TaskHistoryTimeDepth
+    - name: TmProxyAddressDefault

--- a/tango_simlib/tests/test_validator.py
+++ b/tango_simlib/tests/test_validator.py
@@ -200,11 +200,11 @@ def test_validate():
     dev_yaml = YAML_B
     bi_directional_result = compare_data(spec_yaml, dev_yaml, 1)
     single_direction_result = compare_data(spec_yaml, dev_yaml, 0)
-    command_result = (
+    class_result = (
         "Class differs, specified 'DishMaster_A', but device has 'DishMaster_B'"
     )
-    assert command_result in bi_directional_result
-    assert command_result in single_direction_result
+    assert class_result in bi_directional_result
+    assert class_result in single_direction_result
 
     command_result = (
         "Command differs, [ClearTaskHistory_A] specified but missing in device"

--- a/tango_simlib/tests/test_validator.py
+++ b/tango_simlib/tests/test_validator.py
@@ -246,30 +246,36 @@ def test_validate():
     dev_dict = DICT_B
     bi_directional_result = compare_data(spec_dict, dev_dict, 1)
     single_direction_result = compare_data(spec_dict, dev_dict, 0)
-    assert ("Class differs, specified 'DishMaster_A', "
-            "but device has 'DishMaster_B'") in bi_directional_result
+    assert (
+        "Class differs, specified 'DishMaster_A', but device has 'DishMaster_B'"
+    ) in bi_directional_result
 
-    assert ("Command differs, [ClearTaskHistory_A] specified "
-            "but missing in device") in bi_directional_result
+    assert (
+        "Command differs, [ClearTaskHistory_A] specified but missing in device"
+    ) in bi_directional_result
 
-    command_result = ("Command differs, [ClearTaskHistory_B] present in device but not"
-                      " specified")
+    command_result = (
+        "Command differs, [ClearTaskHistory_B] present in device but not specified"
+    )
     assert command_result in bi_directional_result
     assert command_result not in single_direction_result
 
     assert (
         "Command [Capture] differs:\n\tdisp_level:"
-        "\n\t\tspecification: OPERATOR_A, device: OPERATOR_B"
+        "\n\t\tspecification: OPERATOR_A\n\t\tdevice: OPERATOR_B"
     ) in bi_directional_result
 
     # Same in both
     assert "OtherCommand" not in bi_directional_result
 
-    assert ("Attribute differs, [loggingLevelElement_A] specified but"
-            " missing in device") in bi_directional_result
+    assert (
+        "Attribute differs, [loggingLevelElement_A] specified but missing in device"
+    ) in bi_directional_result
 
-    attr_result = ("Attribute differs, [loggingLevelElement_B] present"
-                   " in device but not specified")
+    attr_result = (
+        "Attribute differs, [loggingLevelElement_B] present"
+        " in device but not specified"
+    )
 
     assert attr_result in bi_directional_result
     assert attr_result not in single_direction_result
@@ -281,8 +287,9 @@ def test_validate():
         "Property [ControlModeDefault_A] differs, specified but missing in device"
     ) in bi_directional_result
 
-    prop_res = ("Property [ControlModeDefault_B] differs, present in device but "
-                "not specified")
+    prop_res = (
+        "Property [ControlModeDefault_B] differs, present in device but not specified"
+    )
     assert prop_res in bi_directional_result
     assert prop_res not in single_direction_result
 
@@ -307,7 +314,7 @@ def test_validate():
     )
     assert (
         "Command [Capture] differs:\n\tdisp_level:"
-        "\n\t\tspecification: OPERATOR_B, device: OPERATOR_A"
+        "\n\t\tspecification: OPERATOR_B\n\t\tdevice: OPERATOR_A"
     ) in bi_directional_result
 
     # Same in both

--- a/tango_simlib/tests/test_validator.py
+++ b/tango_simlib/tests/test_validator.py
@@ -1,0 +1,248 @@
+"""Various tests for the validation logic"""
+from __future__ import absolute_import, division, print_function
+
+from tango_simlib.utilities.validate_device import validate_device
+
+YAML_A = """
+{
+  "class": "DishMaster_A",
+  "meta":
+    {
+      "attributes":
+        [
+          {
+            "data_format": "SCALAR_A",
+            "data_type": "DevLong_A",
+            "description": "Current  logging level to Central logging target for this device",
+            "disp_level": "OPERATOR",
+            "display_unit": "No display unit",
+            "format": "%d",
+            "label": "loggingLevelCentral",
+            "max_alarm": "Not specified",
+            "max_dim_x": 1,
+            "max_dim_y": 0,
+            "max_value": "Not specified",
+            "min_alarm": "Not specified",
+            "min_value": "Not specified",
+            "name": "loggingLevelCentral",
+            "standard_unit": "No standard unit",
+            "unit": "",
+            "writable": "READ_WRITE",
+            "writable_attr_name": "logginglevelcentral",
+          },
+          {
+            "data_format": "SCALAR",
+            "data_type": "DevLong",
+            "description": "Current  logging level to Element logging target for this device",
+            "disp_level": "OPERATOR",
+            "display_unit": "No display unit",
+            "format": "%d",
+            "label": "loggingLevelElement",
+            "max_alarm": "Not specified",
+            "max_dim_x": 1,
+            "max_dim_y": 0,
+            "max_value": "Not specified",
+            "min_alarm": "Not specified",
+            "min_value": "Not specified",
+            "name": "loggingLevelElement_A",
+            "standard_unit": "No standard unit",
+            "unit": "",
+            "writable": "READ_WRITE",
+            "writable_attr_name": "logginglevelelement",
+          },
+        ],
+      "commands":
+        [
+          {
+            "disp_level": "OPERATOR_A",
+            "doc_in": "ON/OFF_A",
+            "doc_out": "Uninitialised",
+            "dtype_in": "DevBoolean",
+            "dtype_out": "DevVoid",
+            "name": "Capture",
+          },
+          {
+            "disp_level": "EXPERT",
+            "doc_in": "Uninitialised",
+            "doc_out": "Uninitialised",
+            "dtype_in": "DevVoid",
+            "dtype_out": "DevVoid",
+            "name": "ClearOldTasks",
+          },
+          {
+            "disp_level": "EXPERT",
+            "doc_in": "Uninitialised",
+            "doc_out": "Uninitialised",
+            "dtype_in": "DevVoid",
+            "dtype_out": "DevVoid",
+            "name": "ClearTaskHistory_A",
+          },
+        ],
+      "properties":
+        [
+          { "name": "AdminModeDefault" },
+          { "name": "AsynchCmdReplyNRetries" },
+          { "name": "AsynchCmdReplyTimeout" },
+          { "name": "CentralLoggerEnabledDefault" },
+          { "name": "ConfigureTaskTimeout" },
+          { "name": "ControlModeDefault_A" },
+        ],
+    },
+}
+"""
+
+YAML_B = """
+{
+  "class": "DishMaster_B",
+  "meta":
+    {
+      "attributes":
+        [
+          {
+            "data_format": "SCALAR_B",
+            "data_type": "DevLong_B",
+            "description": "Current  logging level to Central logging target for this device",
+            "disp_level": "OPERATOR",
+            "display_unit": "No display unit",
+            "format": "%d",
+            "label": "loggingLevelCentral",
+            "max_alarm": "Not specified",
+            "max_dim_x": 1,
+            "max_dim_y": 0,
+            "max_value": "Not specified",
+            "min_alarm": "Not specified",
+            "min_value": "Not specified",
+            "name": "loggingLevelCentral",
+            "standard_unit": "No standard unit",
+            "unit": "",
+            "writable": "READ_WRITE",
+            "writable_attr_name": "logginglevelcentral",
+          },
+          {
+            "data_format": "SCALAR",
+            "data_type": "DevLong",
+            "description": "Current  logging level to Element logging target for this device",
+            "disp_level": "OPERATOR",
+            "display_unit": "No display unit",
+            "format": "%d",
+            "label": "loggingLevelElement",
+            "max_alarm": "Not specified",
+            "max_dim_x": 1,
+            "max_dim_y": 0,
+            "max_value": "Not specified",
+            "min_alarm": "Not specified",
+            "min_value": "Not specified",
+            "name": "loggingLevelElement_B",
+            "standard_unit": "No standard unit",
+            "unit": "",
+            "writable": "READ_WRITE",
+            "writable_attr_name": "logginglevelelement",
+          },
+        ],
+      "commands":
+        [
+          {
+            "disp_level": "OPERATOR_B",
+            "doc_in": "ON/OFF_B",
+            "doc_out": "Uninitialised",
+            "dtype_in": "DevBoolean",
+            "dtype_out": "DevVoid",
+            "name": "Capture",
+          },
+          {
+            "disp_level": "EXPERT",
+            "doc_in": "Uninitialised",
+            "doc_out": "Uninitialised",
+            "dtype_in": "DevVoid",
+            "dtype_out": "DevVoid",
+            "name": "ClearOldTasks",
+          },
+          {
+            "disp_level": "EXPERT",
+            "doc_in": "Uninitialised",
+            "doc_out": "Uninitialised",
+            "dtype_in": "DevVoid",
+            "dtype_out": "DevVoid",
+            "name": "ClearTaskHistory_B",
+          },
+        ],
+      "properties":
+        [
+          { "name": "AdminModeDefault" },
+          { "name": "AsynchCmdReplyNRetries" },
+          { "name": "AsynchCmdReplyTimeout" },
+          { "name": "CentralLoggerEnabledDefault" },
+          { "name": "ConfigureTaskTimeout" },
+          { "name": "ControlModeDefault_B" },
+        ],
+    },
+}
+"""
+
+
+def test_validate():
+    """Test various combinations"""
+
+    # If it's the same then no differences recorded
+    assert not validate_device(YAML_A, YAML_A)
+
+    spec_yaml = YAML_A
+    dev_yaml = YAML_B
+    result = validate_device(spec_yaml, dev_yaml)
+    assert (
+        "Class discrepancy, specified 'DishMaster_A', but device has 'DishMaster_B'"
+        in result
+    )
+    assert (
+        "Command discrepancy, {'ClearTaskHistory_A'} specified but missing in device"
+        in result
+    )
+    assert (
+        "Command discrepancy, {'ClearTaskHistory_B'} present in device but not specified"
+        in result
+    )
+    assert (
+        "Command details differ for Capture:\n\tdisp_level:"
+        "\n\t\tspecification: OPERATOR_A, device: OPERATOR_B"
+    ) in result
+
+    assert (
+        "Attribute discrepancy, {'loggingLevelElement_A'} specified but missing in device"
+    ) in result
+
+    assert (
+        ("Attribute discrepancy, {'loggingLevelElement_B'} present"
+         " in device but not specified")
+    ) in result
+
+
+    spec_yaml = YAML_B
+    dev_yaml = YAML_A
+    result = validate_device(spec_yaml, dev_yaml)
+    assert (
+        "Class discrepancy, specified 'DishMaster_B', but device has 'DishMaster_A'"
+        in result
+    )
+    assert (
+        "Command discrepancy, {'ClearTaskHistory_B'} specified but missing in device"
+        in result
+    )
+    assert (
+        "Command discrepancy, {'ClearTaskHistory_A'} present in device but not specified"
+        in result
+    )
+    assert (
+        "Command details differ for Capture:\n\tdisp_level:"
+        "\n\t\tspecification: OPERATOR_B, device: OPERATOR_A"
+    ) in result
+
+    assert (
+        "Attribute discrepancy, {'loggingLevelElement_B'} specified but missing in device"
+    ) in result
+
+    assert (
+        ("Attribute discrepancy, {'loggingLevelElement_A'} present"
+         " in device but not specified")
+    ) in result
+
+    print(result)

--- a/tango_simlib/tests/test_validator.py
+++ b/tango_simlib/tests/test_validator.py
@@ -3,236 +3,188 @@ from __future__ import absolute_import, division, print_function
 
 from tango_simlib.utilities.validate_device import compare_data
 
-DICT_A = """
-{
-  "class": "DishMaster_A",
-  "meta":
-    {
-      "attributes":
-        [
-          {
-            "data_format": "SCALAR_A",
-            "data_type": "DevLong_A",
-            "description": "Current  logging level to Central logging target",
-            "disp_level": "OPERATOR",
-            "display_unit": "No display unit",
-            "format": "%d",
-            "label": "loggingLevelCentral",
-            "max_alarm": "Not specified",
-            "max_dim_x": 1,
-            "max_dim_y": 0,
-            "max_value": "Not specified",
-            "min_alarm": "Not specified",
-            "min_value": "Not specified",
-            "name": "loggingLevelCentral",
-            "standard_unit": "No standard unit",
-            "unit": "",
-            "writable": "READ_WRITE",
-            "writable_attr_name": "logginglevelcentral",
-          },
-          {
-            "data_format": "SCALAR",
-            "data_type": "DevLong",
-            "description": "Current  logging level to Element logging target",
-            "disp_level": "OPERATOR",
-            "display_unit": "No display unit",
-            "format": "%d",
-            "label": "loggingLevelElement",
-            "max_alarm": "Not specified",
-            "max_dim_x": 1,
-            "max_dim_y": 0,
-            "max_value": "Not specified",
-            "min_alarm": "Not specified",
-            "min_value": "Not specified",
-            "name": "loggingLevelElement_A",
-            "standard_unit": "No standard unit",
-            "unit": "",
-            "writable": "READ_WRITE",
-            "writable_attr_name": "logginglevelelement",
-          },
-          {
-            "data_format": "SCALAR",
-            "data_type": "DevLong",
-            "description": "Current  logging level to logging target",
-            "disp_level": "OPERATOR",
-            "display_unit": "No display unit",
-            "format": "%d",
-            "label": "loggingLevel",
-            "max_alarm": "Not specified",
-            "max_dim_x": 1,
-            "max_dim_y": 0,
-            "max_value": "Not specified",
-            "min_alarm": "Not specified",
-            "min_value": "Not specified",
-            "name": "OtherAttribute",
-            "standard_unit": "No standard unit",
-            "unit": "",
-            "writable": "READ_WRITE",
-            "writable_attr_name": "logginglevel",
-          },
-        ],
-      "commands":
-        [
-          {
-            "disp_level": "OPERATOR_A",
-            "doc_in": "ON/OFF_A",
-            "doc_out": "Uninitialised",
-            "dtype_in": "DevBoolean",
-            "dtype_out": "DevVoid",
-            "name": "Capture",
-          },
-          {
-            "disp_level": "EXPERT",
-            "doc_in_A": "Uninitialised",
-            "doc_out": "Uninitialised",
-            "dtype_in": "DevVoid",
-            "dtype_out": "DevVoid",
-            "name": "ClearOldTasks",
-          },
-          {
-            "disp_level": "EXPERT",
-            "doc_in": "Uninitialised",
-            "doc_out": "Uninitialised",
-            "dtype_in": "DevVoid",
-            "dtype_out": "DevVoid",
-            "name": "ClearTaskHistory_A",
-          },
-          {
-            "disp_level": "EXPERT",
-            "doc_in": "Uninitialised",
-            "doc_out": "Uninitialised",
-            "dtype_in": "DevVoid",
-            "dtype_out": "DevVoid",
-            "name": "OtherCommand",
-          },
-        ],
-      "properties":
-        [
-          { "name": "AdminModeDefault" },
-          { "name": "AsynchCmdReplyNRetries" },
-          { "name": "AsynchCmdReplyTimeout" },
-          { "name": "CentralLoggerEnabledDefault" },
-          { "name": "ConfigureTaskTimeout" },
-          { "name": "ControlModeDefault_A" },
-        ],
-    },
-}
+YAML_A = """
+class: DishMaster_A
+meta:
+  attributes:
+  - data_format: SCALAR_A
+    data_type: DevLong_A
+    description: Current  logging level to Central logging target
+    disp_level: OPERATOR
+    display_unit: No display unit
+    format: '%d'
+    label: loggingLevelCentral
+    max_alarm: Not specified
+    max_dim_x: 1
+    max_dim_y: 0
+    max_value: Not specified
+    min_alarm: Not specified
+    min_value: Not specified
+    name: loggingLevelCentral
+    standard_unit: No standard unit
+    unit: ''
+    writable: READ_WRITE
+    writable_attr_name: logginglevelcentral
+  - data_format: SCALAR
+    data_type: DevLong
+    description: Current  logging level to Element logging target
+    disp_level: OPERATOR
+    display_unit: No display unit
+    format: '%d'
+    label: loggingLevelElement
+    max_alarm: Not specified
+    max_dim_x: 1
+    max_dim_y: 0
+    max_value: Not specified
+    min_alarm: Not specified
+    min_value: Not specified
+    name: loggingLevelElement_A
+    standard_unit: No standard unit
+    unit: ''
+    writable: READ_WRITE
+    writable_attr_name: logginglevelelement
+  - data_format: SCALAR
+    data_type: DevLong
+    description: Current  logging level to logging target
+    disp_level: OPERATOR
+    display_unit: No display unit
+    format: '%d'
+    label: loggingLevel
+    max_alarm: Not specified
+    max_dim_x: 1
+    max_dim_y: 0
+    max_value: Not specified
+    min_alarm: Not specified
+    min_value: Not specified
+    name: OtherAttribute
+    standard_unit: No standard unit
+    unit: ''
+    writable: READ_WRITE
+    writable_attr_name: logginglevel
+  commands:
+  - disp_level: OPERATOR_A
+    doc_in: ON/OFF_A
+    doc_out: Uninitialised
+    dtype_in: DevBoolean
+    dtype_out: DevVoid
+    name: Capture
+  - disp_level: EXPERT
+    doc_in_A: Uninitialised
+    doc_out: Uninitialised
+    dtype_in: DevVoid
+    dtype_out: DevVoid
+    name: ClearOldTasks
+  - disp_level: EXPERT
+    doc_in: Uninitialised
+    doc_out: Uninitialised
+    dtype_in: DevVoid
+    dtype_out: DevVoid
+    name: ClearTaskHistory_A
+  - disp_level: EXPERT
+    doc_in: Uninitialised
+    doc_out: Uninitialised
+    dtype_in: DevVoid
+    dtype_out: DevVoid
+    name: OtherCommand
+  properties:
+  - name: AdminModeDefault
+  - name: AsynchCmdReplyNRetries
+  - name: AsynchCmdReplyTimeout
+  - name: CentralLoggerEnabledDefault
+  - name: ConfigureTaskTimeout
+  - name: ControlModeDefault_A
 """
 
-DICT_B = """
-{
-  "class": "DishMaster_B",
-  "meta":
-    {
-      "attributes":
-        [
-          {
-            "data_format": "SCALAR_B",
-            "data_type": "DevLong_B",
-            "description": "Current  logging level to Central logging target",
-            "disp_level": "OPERATOR",
-            "display_unit": "No display unit",
-            "format": "%d",
-            "label": "loggingLevelCentral",
-            "max_alarm": "Not specified",
-            "max_dim_x": 1,
-            "max_dim_y": 0,
-            "max_value": "Not specified",
-            "min_alarm": "Not specified",
-            "min_value": "Not specified",
-            "name": "loggingLevelCentral",
-            "standard_unit": "No standard unit",
-            "unit": "",
-            "writable": "READ_WRITE",
-            "writable_attr_name": "logginglevelcentral",
-          },
-          {
-            "data_format": "SCALAR",
-            "data_type": "DevLong",
-            "description": "Current  logging level to Element logging target",
-            "disp_level": "OPERATOR",
-            "display_unit": "No display unit",
-            "format": "%d",
-            "label": "loggingLevelElement",
-            "max_alarm": "Not specified",
-            "max_dim_x": 1,
-            "max_dim_y": 0,
-            "max_value": "Not specified",
-            "min_alarm": "Not specified",
-            "min_value": "Not specified",
-            "name": "loggingLevelElement_B",
-            "standard_unit": "No standard unit",
-            "unit": "",
-            "writable": "READ_WRITE",
-            "writable_attr_name": "logginglevelelement",
-          },
-          {
-            "data_format": "SCALAR",
-            "data_type": "DevLong",
-            "description": "Current  logging level to logging target",
-            "disp_level": "OPERATOR",
-            "display_unit": "No display unit",
-            "format": "%d",
-            "label": "loggingLevel",
-            "max_alarm": "Not specified",
-            "max_dim_x": 1,
-            "max_dim_y": 0,
-            "max_value": "Not specified",
-            "min_alarm": "Not specified",
-            "min_value": "Not specified",
-            "name": "OtherAttribute",
-            "standard_unit": "No standard unit",
-            "unit": "",
-            "writable": "READ_WRITE",
-            "writable_attr_name": "logginglevel",
-          },
-        ],
-      "commands":
-        [
-          {
-            "disp_level": "OPERATOR_B",
-            "doc_in": "ON/OFF_B",
-            "doc_out": "Uninitialised",
-            "dtype_in": "DevBoolean",
-            "dtype_out": "DevVoid",
-            "name": "Capture",
-          },
-          {
-            "disp_level": "EXPERT",
-            "doc_in": "Uninitialised",
-            "doc_out_B": "Uninitialised",
-            "dtype_in": "DevVoid",
-            "dtype_out": "DevVoid",
-            "name": "ClearOldTasks",
-          },
-          {
-            "disp_level": "EXPERT",
-            "doc_in": "Uninitialised",
-            "doc_out": "Uninitialised",
-            "dtype_in": "DevVoid",
-            "dtype_out": "DevVoid",
-            "name": "ClearTaskHistory_B",
-          },
-          {
-            "disp_level": "EXPERT",
-            "doc_in": "Uninitialised",
-            "doc_out": "Uninitialised",
-            "dtype_in": "DevVoid",
-            "dtype_out": "DevVoid",
-            "name": "OtherCommand",
-          },
-        ],
-      "properties":
-        [
-          { "name": "AdminModeDefault" },
-          { "name": "AsynchCmdReplyNRetries" },
-          { "name": "AsynchCmdReplyTimeout" },
-          { "name": "CentralLoggerEnabledDefault" },
-          { "name": "ConfigureTaskTimeout" },
-          { "name": "ControlModeDefault_B" },
-        ],
-    },
-}
+YAML_B = """
+class: DishMaster_B
+meta:
+  attributes:
+  - data_format: SCALAR_B
+    data_type: DevLong_B
+    description: Current  logging level to Central logging target
+    disp_level: OPERATOR
+    display_unit: No display unit
+    format: '%d'
+    label: loggingLevelCentral
+    max_alarm: Not specified
+    max_dim_x: 1
+    max_dim_y: 0
+    max_value: Not specified
+    min_alarm: Not specified
+    min_value: Not specified
+    name: loggingLevelCentral
+    standard_unit: No standard unit
+    unit: ''
+    writable: READ_WRITE
+    writable_attr_name: logginglevelcentral
+  - data_format: SCALAR
+    data_type: DevLong
+    description: Current  logging level to Element logging target
+    disp_level: OPERATOR
+    display_unit: No display unit
+    format: '%d'
+    label: loggingLevelElement
+    max_alarm: Not specified
+    max_dim_x: 1
+    max_dim_y: 0
+    max_value: Not specified
+    min_alarm: Not specified
+    min_value: Not specified
+    name: loggingLevelElement_B
+    standard_unit: No standard unit
+    unit: ''
+    writable: READ_WRITE
+    writable_attr_name: logginglevelelement
+  - data_format: SCALAR
+    data_type: DevLong
+    description: Current  logging level to logging target
+    disp_level: OPERATOR
+    display_unit: No display unit
+    format: '%d'
+    label: loggingLevel
+    max_alarm: Not specified
+    max_dim_x: 1
+    max_dim_y: 0
+    max_value: Not specified
+    min_alarm: Not specified
+    min_value: Not specified
+    name: OtherAttribute
+    standard_unit: No standard unit
+    unit: ''
+    writable: READ_WRITE
+    writable_attr_name: logginglevel
+  commands:
+  - disp_level: OPERATOR_B
+    doc_in: ON/OFF_B
+    doc_out: Uninitialised
+    dtype_in: DevBoolean
+    dtype_out: DevVoid
+    name: Capture
+  - disp_level: EXPERT
+    doc_in: Uninitialised
+    doc_out_B: Uninitialised
+    dtype_in: DevVoid
+    dtype_out: DevVoid
+    name: ClearOldTasks
+  - disp_level: EXPERT
+    doc_in: Uninitialised
+    doc_out: Uninitialised
+    dtype_in: DevVoid
+    dtype_out: DevVoid
+    name: ClearTaskHistory_B
+  - disp_level: EXPERT
+    doc_in: Uninitialised
+    doc_out: Uninitialised
+    dtype_in: DevVoid
+    dtype_out: DevVoid
+    name: OtherCommand
+  properties:
+  - name: AdminModeDefault
+  - name: AsynchCmdReplyNRetries
+  - name: AsynchCmdReplyTimeout
+  - name: CentralLoggerEnabledDefault
+  - name: ConfigureTaskTimeout
+  - name: ControlModeDefault_B
 """
 
 
@@ -240,12 +192,12 @@ def test_validate():
     """Test various combinations"""
 
     # If it's the same then no differences recorded
-    assert not compare_data(DICT_A, DICT_A, 1)
+    assert not compare_data(YAML_A, YAML_A, 1)
 
-    spec_dict = DICT_A
-    dev_dict = DICT_B
-    bi_directional_result = compare_data(spec_dict, dev_dict, 1)
-    single_direction_result = compare_data(spec_dict, dev_dict, 0)
+    spec_yaml = YAML_A
+    dev_yaml = YAML_B
+    bi_directional_result = compare_data(spec_yaml, dev_yaml, 1)
+    single_direction_result = compare_data(spec_yaml, dev_yaml, 0)
     command_result = (
         "Class differs, specified 'DishMaster_A', but device has 'DishMaster_B'"
     )
@@ -306,9 +258,9 @@ def test_validate():
     assert "AdminModeDefault" not in bi_directional_result
     assert "AdminModeDefault" not in single_direction_result
 
-    spec_dict = DICT_B
-    dev_dict = DICT_A
-    bi_directional_result = compare_data(spec_dict, dev_dict, 1)
+    spec_yaml = YAML_B
+    dev_yaml = YAML_A
+    bi_directional_result = compare_data(spec_yaml, dev_yaml, 1)
 
     assert (
         "lass differs, specified 'DishMaster_B', but device has 'DishMaster_A'"

--- a/tango_simlib/tests/test_validator.py
+++ b/tango_simlib/tests/test_validator.py
@@ -13,7 +13,7 @@ DICT_A = """
           {
             "data_format": "SCALAR_A",
             "data_type": "DevLong_A",
-            "description": "Current  logging level to Central logging target for this device",
+            "description": "Current  logging level to Central logging target",
             "disp_level": "OPERATOR",
             "display_unit": "No display unit",
             "format": "%d",
@@ -33,7 +33,7 @@ DICT_A = """
           {
             "data_format": "SCALAR",
             "data_type": "DevLong",
-            "description": "Current  logging level to Element logging target for this device",
+            "description": "Current  logging level to Element logging target",
             "disp_level": "OPERATOR",
             "display_unit": "No display unit",
             "format": "%d",
@@ -53,7 +53,7 @@ DICT_A = """
           {
             "data_format": "SCALAR",
             "data_type": "DevLong",
-            "description": "Current  logging level to logging target for this device",
+            "description": "Current  logging level to logging target",
             "disp_level": "OPERATOR",
             "display_unit": "No display unit",
             "format": "%d",
@@ -129,7 +129,7 @@ DICT_B = """
           {
             "data_format": "SCALAR_B",
             "data_type": "DevLong_B",
-            "description": "Current  logging level to Central logging target for this device",
+            "description": "Current  logging level to Central logging target",
             "disp_level": "OPERATOR",
             "display_unit": "No display unit",
             "format": "%d",
@@ -149,7 +149,7 @@ DICT_B = """
           {
             "data_format": "SCALAR",
             "data_type": "DevLong",
-            "description": "Current  logging level to Element logging target for this device",
+            "description": "Current  logging level to Element logging target",
             "disp_level": "OPERATOR",
             "display_unit": "No display unit",
             "format": "%d",
@@ -169,7 +169,7 @@ DICT_B = """
           {
             "data_format": "SCALAR",
             "data_type": "DevLong",
-            "description": "Current  logging level to logging target for this device",
+            "description": "Current  logging level to logging target",
             "disp_level": "OPERATOR",
             "display_unit": "No display unit",
             "format": "%d",
@@ -240,102 +240,102 @@ def test_validate():
     """Test various combinations"""
 
     # If it's the same then no differences recorded
-    assert not compare_data(DICT_A, DICT_A)
+    assert not compare_data(DICT_A, DICT_A, 1)
 
     spec_dict = DICT_A
     dev_dict = DICT_B
-    result = compare_data(spec_dict, dev_dict)
-    assert (
-        "Class differs, specified 'DishMaster_A', but device has 'DishMaster_B'" in result
-    )
-    assert (
-        "Command differs, [ClearTaskHistory_A] specified but missing in device" in result
-    )
-    assert (
-        "Command differs, [ClearTaskHistory_B] present in device but not specified"
-        in result
-    )
+    bi_directional_result = compare_data(spec_dict, dev_dict, 1)
+    single_direction_result = compare_data(spec_dict, dev_dict, 0)
+    assert ("Class differs, specified 'DishMaster_A', "
+            "but device has 'DishMaster_B'") in bi_directional_result
+
+    assert ("Command differs, [ClearTaskHistory_A] specified "
+            "but missing in device") in bi_directional_result
+
+    command_result = ("Command differs, [ClearTaskHistory_B] present in device but not"
+                      " specified")
+    assert command_result in bi_directional_result
+    assert command_result not in single_direction_result
+
     assert (
         "Command [Capture] differs:\n\tdisp_level:"
         "\n\t\tspecification: OPERATOR_A, device: OPERATOR_B"
-    ) in result
+    ) in bi_directional_result
 
     # Same in both
-    assert "OtherCommand" not in result
+    assert "OtherCommand" not in bi_directional_result
 
-    assert (
-        "Attribute differs, [loggingLevelElement_A] specified but missing in device"
-    ) in result
+    assert ("Attribute differs, [loggingLevelElement_A] specified but"
+            " missing in device") in bi_directional_result
 
-    assert (
-        (
-            "Attribute differs, [loggingLevelElement_B] present"
-            " in device but not specified"
-        )
-    ) in result
+    attr_result = ("Attribute differs, [loggingLevelElement_B] present"
+                   " in device but not specified")
+
+    assert attr_result in bi_directional_result
+    assert attr_result not in single_direction_result
 
     # Same in both
-    assert "OtherAttribute" not in result
+    assert "OtherAttribute" not in bi_directional_result
 
     assert (
-        ("Property [ControlModeDefault_A] differs, specified but missing in device")
-    ) in result
+        "Property [ControlModeDefault_A] differs, specified but missing in device"
+    ) in bi_directional_result
 
-    assert (
-        (
-            "Property [ControlModeDefault_B] differs, present in device but "
-            "not specified"
-        )
-    ) in result
+    prop_res = ("Property [ControlModeDefault_B] differs, present in device but "
+                "not specified")
+    assert prop_res in bi_directional_result
+    assert prop_res not in single_direction_result
 
     # Same in both
-    assert "AdminModeDefault" not in result
+    assert "AdminModeDefault" not in bi_directional_result
 
     spec_dict = DICT_B
     dev_dict = DICT_A
-    result = compare_data(spec_dict, dev_dict)
+    bi_directional_result = compare_data(spec_dict, dev_dict, 1)
 
     assert (
-        "Class differs, specified 'DishMaster_B', but device has 'DishMaster_A'" in result
+        "lass differs, specified 'DishMaster_B', but device has 'DishMaster_A'"
+        in bi_directional_result
     )
     assert (
-        "Command differs, [ClearTaskHistory_B] specified but missing in device" in result
+        "Command differs, [ClearTaskHistory_B] specified but missing in device"
+        in bi_directional_result
     )
     assert (
         "Command differs, [ClearTaskHistory_A] present in device but not specified"
-        in result
+        in bi_directional_result
     )
     assert (
         "Command [Capture] differs:\n\tdisp_level:"
         "\n\t\tspecification: OPERATOR_B, device: OPERATOR_A"
-    ) in result
+    ) in bi_directional_result
 
     # Same in both
-    assert "OtherCommand" not in result
+    assert "OtherCommand" not in bi_directional_result
 
     assert (
         "Attribute differs, [loggingLevelElement_B] specified but missing in device"
-    ) in result
+    ) in bi_directional_result
 
     assert (
         (
             "Attribute differs, [loggingLevelElement_A] present"
             " in device but not specified"
         )
-    ) in result
+    ) in bi_directional_result
 
-    assert "OtherAttribute" not in result
+    assert "OtherAttribute" not in bi_directional_result
 
     assert (
         ("Property [ControlModeDefault_B] differs, specified but missing in device")
-    ) in result
+    ) in bi_directional_result
 
     assert (
         (
             "Property [ControlModeDefault_A] differs, present in device but "
             "not specified"
         )
-    ) in result
+    ) in bi_directional_result
 
     # Same in both
-    assert "AdminModeDefault" not in result
+    assert "AdminModeDefault" not in bi_directional_result

--- a/tango_simlib/tests/test_validator.py
+++ b/tango_simlib/tests/test_validator.py
@@ -1,7 +1,7 @@
 """Various tests for the validation logic"""
 from __future__ import absolute_import, division, print_function
 
-from tango_simlib.utilities.validate_device import validate_device
+from tango_simlib.utilities.validate_device import compare_data
 
 DICT_A = """
 {
@@ -184,11 +184,11 @@ def test_validate():
     """Test various combinations"""
 
     # If it's the same then no differences recorded
-    assert not validate_device(DICT_A, DICT_A)
+    assert not compare_data(DICT_A, DICT_A)
 
     spec_dict = DICT_A
     dev_dict = DICT_B
-    result = validate_device(spec_dict, dev_dict)
+    result = compare_data(spec_dict, dev_dict)
     assert (
         "Class discrepancy, specified 'DishMaster_A', but device has 'DishMaster_B'"
         in result
@@ -230,7 +230,7 @@ def test_validate():
 
     spec_dict = DICT_B
     dev_dict = DICT_A
-    result = validate_device(spec_dict, dev_dict)
+    result = compare_data(spec_dict, dev_dict)
 
     assert (
         "Class discrepancy, specified 'DishMaster_B', but device has 'DishMaster_A'"

--- a/tango_simlib/tests/test_validator.py
+++ b/tango_simlib/tests/test_validator.py
@@ -348,7 +348,7 @@ def test_invalid_spec():
     """Make sure that the minimal spec format is checked"""
     try:
         compare_data("class:", YAML_A, 0)
-    except AssertionError as e:
-        assert "Minimal structure not adhered to" in str(e)
+    except AssertionError as err:
+        assert "Minimal structure not adhered to" in str(err)
     else:
         assert 0, "AssertionError not raised for invalid spec format"

--- a/tango_simlib/tests/test_validator.py
+++ b/tango_simlib/tests/test_validator.py
@@ -3,7 +3,7 @@ from __future__ import absolute_import, division, print_function
 
 from tango_simlib.utilities.validate_device import validate_device
 
-YAML_A = """
+DICT_A = """
 {
   "class": "DishMaster_A",
   "meta":
@@ -91,7 +91,7 @@ YAML_A = """
 }
 """
 
-YAML_B = """
+DICT_B = """
 {
   "class": "DishMaster_B",
   "meta":
@@ -184,11 +184,11 @@ def test_validate():
     """Test various combinations"""
 
     # If it's the same then no differences recorded
-    assert not validate_device(YAML_A, YAML_A)
+    assert not validate_device(DICT_A, DICT_A)
 
-    spec_yaml = YAML_A
-    dev_yaml = YAML_B
-    result = validate_device(spec_yaml, dev_yaml)
+    spec_dict = DICT_A
+    dev_dict = DICT_B
+    result = validate_device(spec_dict, dev_dict)
     assert (
         "Class discrepancy, specified 'DishMaster_A', but device has 'DishMaster_B'"
         in result
@@ -217,9 +217,21 @@ def test_validate():
         )
     ) in result
 
-    spec_yaml = YAML_B
-    dev_yaml = YAML_A
-    result = validate_device(spec_yaml, dev_yaml)
+    assert (
+        ("Property discrepancy, [ControlModeDefault_A] specified but missing in device")
+    ) in result
+
+    assert (
+        (
+            "Property discrepancy, [ControlModeDefault_B] present in device but "
+            "not specified"
+        )
+    ) in result
+
+    spec_dict = DICT_B
+    dev_dict = DICT_A
+    result = validate_device(spec_dict, dev_dict)
+
     assert (
         "Class discrepancy, specified 'DishMaster_B', but device has 'DishMaster_A'"
         in result
@@ -245,5 +257,16 @@ def test_validate():
         (
             "Attribute discrepancy, [loggingLevelElement_A] present"
             " in device but not specified"
+        )
+    ) in result
+
+    assert (
+        ("Property discrepancy, [ControlModeDefault_B] specified but missing in device")
+    ) in result
+
+    assert (
+        (
+            "Property discrepancy, [ControlModeDefault_A] present in device but "
+            "not specified"
         )
     ) in result

--- a/tango_simlib/tests/test_validator.py
+++ b/tango_simlib/tests/test_validator.py
@@ -194,11 +194,11 @@ def test_validate():
         in result
     )
     assert (
-        "Command discrepancy, {'ClearTaskHistory_A'} specified but missing in device"
+        "Command discrepancy, [ClearTaskHistory_A] specified but missing in device"
         in result
     )
     assert (
-        "Command discrepancy, {'ClearTaskHistory_B'} present in device but not specified"
+        "Command discrepancy, [ClearTaskHistory_B] present in device but not specified"
         in result
     )
     assert (
@@ -207,14 +207,15 @@ def test_validate():
     ) in result
 
     assert (
-        "Attribute discrepancy, {'loggingLevelElement_A'} specified but missing in device"
+        "Attribute discrepancy, [loggingLevelElement_A] specified but missing in device"
     ) in result
 
     assert (
-        ("Attribute discrepancy, {'loggingLevelElement_B'} present"
-         " in device but not specified")
+        (
+            "Attribute discrepancy, [loggingLevelElement_B] present"
+            " in device but not specified"
+        )
     ) in result
-
 
     spec_yaml = YAML_B
     dev_yaml = YAML_A
@@ -224,11 +225,11 @@ def test_validate():
         in result
     )
     assert (
-        "Command discrepancy, {'ClearTaskHistory_B'} specified but missing in device"
+        "Command discrepancy, [ClearTaskHistory_B] specified but missing in device"
         in result
     )
     assert (
-        "Command discrepancy, {'ClearTaskHistory_A'} present in device but not specified"
+        "Command discrepancy, [ClearTaskHistory_A] present in device but not specified"
         in result
     )
     assert (
@@ -237,12 +238,14 @@ def test_validate():
     ) in result
 
     assert (
-        "Attribute discrepancy, {'loggingLevelElement_B'} specified but missing in device"
+        "Attribute discrepancy, [loggingLevelElement_B] specified but missing in device"
     ) in result
 
     assert (
-        ("Attribute discrepancy, {'loggingLevelElement_A'} present"
-         " in device but not specified")
+        (
+            "Attribute discrepancy, [loggingLevelElement_A] present"
+            " in device but not specified"
+        )
     ) in result
 
     print(result)

--- a/tango_simlib/tests/test_validator.py
+++ b/tango_simlib/tests/test_validator.py
@@ -187,6 +187,14 @@ meta:
   - name: ControlModeDefault_B
 """
 
+YAML_EMPTY = """
+class:
+meta:
+  attributes:
+  commands:
+  properties:
+"""
+
 
 def test_validate():
     """Test various combinations"""
@@ -308,3 +316,39 @@ def test_validate():
 
     # Same in both
     assert "AdminModeDefault" not in bi_directional_result
+
+
+def test_empty_validation():
+    """Check that a empty spec is still works"""
+    single_direction_result = compare_data(YAML_EMPTY, YAML_A, 0)
+    assert not single_direction_result
+
+    bi_direction_result = compare_data(YAML_EMPTY, YAML_A, 1)
+    command_res = (
+        "Command differs, [Capture,ClearOldTasks,ClearTaskHistory_A,OtherCommand]"
+        " present in device but not specified"
+    )
+    assert command_res in bi_direction_result
+
+    attr_res = (
+        "Attribute differs, [OtherAttribute,loggingLevelCentral,loggingLevelElement_A]"
+        " present in device but not specified"
+    )
+    assert attr_res in bi_direction_result
+
+    prop_res = (
+        "Property [AdminModeDefault,AsynchCmdReplyNRetries,AsynchCmdReplyTimeout,"
+        "CentralLoggerEnabledDefault,ConfigureTaskTimeout,ControlModeDefault_A] differs,"
+        " present in device but not specified"
+    )
+    assert prop_res in bi_direction_result
+
+
+def test_invalid_spec():
+    """Make sure that the minimal spec format is checked"""
+    try:
+        compare_data("class:", YAML_A, 0)
+    except AssertionError as e:
+        assert "Minimal structure not adhered to" in str(e)
+    else:
+        assert 0, "AssertionError not raised for invalid spec format"

--- a/tango_simlib/tests/test_validator.py
+++ b/tango_simlib/tests/test_validator.py
@@ -246,13 +246,17 @@ def test_validate():
     dev_dict = DICT_B
     bi_directional_result = compare_data(spec_dict, dev_dict, 1)
     single_direction_result = compare_data(spec_dict, dev_dict, 0)
-    assert (
+    command_result = (
         "Class differs, specified 'DishMaster_A', but device has 'DishMaster_B'"
-    ) in bi_directional_result
+    )
+    assert command_result in bi_directional_result
+    assert command_result in single_direction_result
 
-    assert (
+    command_result = (
         "Command differs, [ClearTaskHistory_A] specified but missing in device"
-    ) in bi_directional_result
+    )
+    assert command_result in bi_directional_result
+    assert command_result in single_direction_result
 
     command_result = (
         "Command differs, [ClearTaskHistory_B] present in device but not specified"
@@ -260,32 +264,37 @@ def test_validate():
     assert command_result in bi_directional_result
     assert command_result not in single_direction_result
 
-    assert (
+    command_result = (
         "Command [Capture] differs:\n\tdisp_level:"
         "\n\t\tspecification: OPERATOR_A\n\t\tdevice: OPERATOR_B"
-    ) in bi_directional_result
+    )
+    assert command_result in bi_directional_result
+    assert command_result in single_direction_result
 
     # Same in both
     assert "OtherCommand" not in bi_directional_result
+    assert "OtherCommand" not in single_direction_result
 
-    assert (
+    attr_result = (
         "Attribute differs, [loggingLevelElement_A] specified but missing in device"
-    ) in bi_directional_result
+    )
+    assert attr_result in bi_directional_result
+    assert attr_result in single_direction_result
 
     attr_result = (
         "Attribute differs, [loggingLevelElement_B] present"
         " in device but not specified"
     )
-
     assert attr_result in bi_directional_result
     assert attr_result not in single_direction_result
 
     # Same in both
     assert "OtherAttribute" not in bi_directional_result
+    assert "OtherAttribute" not in single_direction_result
 
-    assert (
-        "Property [ControlModeDefault_A] differs, specified but missing in device"
-    ) in bi_directional_result
+    prop_res = "Property [ControlModeDefault_A] differs, specified but missing in device"
+    assert prop_res in bi_directional_result
+    assert prop_res in single_direction_result
 
     prop_res = (
         "Property [ControlModeDefault_B] differs, present in device but not specified"
@@ -295,6 +304,7 @@ def test_validate():
 
     # Same in both
     assert "AdminModeDefault" not in bi_directional_result
+    assert "AdminModeDefault" not in single_direction_result
 
     spec_dict = DICT_B
     dev_dict = DICT_A

--- a/tango_simlib/tests/test_validator.py
+++ b/tango_simlib/tests/test_validator.py
@@ -265,7 +265,7 @@ def test_validate():
     bi_directional_result = compare_data(spec_yaml, dev_yaml, 1)
 
     assert (
-        "lass differs, specified 'DishMaster_B', but device has 'DishMaster_A'"
+        "Class differs, specified 'DishMaster_B', but device has 'DishMaster_A'"
         in bi_directional_result
     )
     assert (

--- a/tango_simlib/tests/test_validator.py
+++ b/tango_simlib/tests/test_validator.py
@@ -247,5 +247,3 @@ def test_validate():
             " in device but not specified"
         )
     ) in result
-
-    print(result)

--- a/tango_simlib/tests/test_validator.py
+++ b/tango_simlib/tests/test_validator.py
@@ -63,7 +63,7 @@ DICT_A = """
           },
           {
             "disp_level": "EXPERT",
-            "doc_in": "Uninitialised",
+            "doc_in_A": "Uninitialised",
             "doc_out": "Uninitialised",
             "dtype_in": "DevVoid",
             "dtype_out": "DevVoid",
@@ -152,7 +152,7 @@ DICT_B = """
           {
             "disp_level": "EXPERT",
             "doc_in": "Uninitialised",
-            "doc_out": "Uninitialised",
+            "doc_out_B": "Uninitialised",
             "dtype_in": "DevVoid",
             "dtype_out": "DevVoid",
             "name": "ClearOldTasks",
@@ -190,40 +190,38 @@ def test_validate():
     dev_dict = DICT_B
     result = compare_data(spec_dict, dev_dict)
     assert (
-        "Class discrepancy, specified 'DishMaster_A', but device has 'DishMaster_B'"
+        "Class differs, specified 'DishMaster_A', but device has 'DishMaster_B'" in result
+    )
+    assert (
+        "Command differs, [ClearTaskHistory_A] specified but missing in device" in result
+    )
+    assert (
+        "Command differs, [ClearTaskHistory_B] present in device but not specified"
         in result
     )
     assert (
-        "Command discrepancy, [ClearTaskHistory_A] specified but missing in device"
-        in result
-    )
-    assert (
-        "Command discrepancy, [ClearTaskHistory_B] present in device but not specified"
-        in result
-    )
-    assert (
-        "Command details differ for Capture:\n\tdisp_level:"
+        "Command [Capture] differs:\n\tdisp_level:"
         "\n\t\tspecification: OPERATOR_A, device: OPERATOR_B"
     ) in result
 
     assert (
-        "Attribute discrepancy, [loggingLevelElement_A] specified but missing in device"
+        "Attribute differs, [loggingLevelElement_A] specified but missing in device"
     ) in result
 
     assert (
         (
-            "Attribute discrepancy, [loggingLevelElement_B] present"
+            "Attribute differs, [loggingLevelElement_B] present"
             " in device but not specified"
         )
     ) in result
 
     assert (
-        ("Property discrepancy, [ControlModeDefault_A] specified but missing in device")
+        ("Property [ControlModeDefault_A] differs, specified but missing in device")
     ) in result
 
     assert (
         (
-            "Property discrepancy, [ControlModeDefault_B] present in device but "
+            "Property [ControlModeDefault_B] differs, present in device but "
             "not specified"
         )
     ) in result
@@ -233,40 +231,38 @@ def test_validate():
     result = compare_data(spec_dict, dev_dict)
 
     assert (
-        "Class discrepancy, specified 'DishMaster_B', but device has 'DishMaster_A'"
+        "Class differs, specified 'DishMaster_B', but device has 'DishMaster_A'" in result
+    )
+    assert (
+        "Command differs, [ClearTaskHistory_B] specified but missing in device" in result
+    )
+    assert (
+        "Command differs, [ClearTaskHistory_A] present in device but not specified"
         in result
     )
     assert (
-        "Command discrepancy, [ClearTaskHistory_B] specified but missing in device"
-        in result
-    )
-    assert (
-        "Command discrepancy, [ClearTaskHistory_A] present in device but not specified"
-        in result
-    )
-    assert (
-        "Command details differ for Capture:\n\tdisp_level:"
+        "Command [Capture] differs:\n\tdisp_level:"
         "\n\t\tspecification: OPERATOR_B, device: OPERATOR_A"
     ) in result
 
     assert (
-        "Attribute discrepancy, [loggingLevelElement_B] specified but missing in device"
+        "Attribute differs, [loggingLevelElement_B] specified but missing in device"
     ) in result
 
     assert (
         (
-            "Attribute discrepancy, [loggingLevelElement_A] present"
+            "Attribute differs, [loggingLevelElement_A] present"
             " in device but not specified"
         )
     ) in result
 
     assert (
-        ("Property discrepancy, [ControlModeDefault_B] specified but missing in device")
+        ("Property [ControlModeDefault_B] differs, specified but missing in device")
     ) in result
 
     assert (
         (
-            "Property discrepancy, [ControlModeDefault_A] present in device but "
+            "Property [ControlModeDefault_A] differs, present in device but "
             "not specified"
         )
     ) in result

--- a/tango_simlib/tests/test_validator.py
+++ b/tango_simlib/tests/test_validator.py
@@ -50,6 +50,26 @@ DICT_A = """
             "writable": "READ_WRITE",
             "writable_attr_name": "logginglevelelement",
           },
+          {
+            "data_format": "SCALAR",
+            "data_type": "DevLong",
+            "description": "Current  logging level to logging target for this device",
+            "disp_level": "OPERATOR",
+            "display_unit": "No display unit",
+            "format": "%d",
+            "label": "loggingLevel",
+            "max_alarm": "Not specified",
+            "max_dim_x": 1,
+            "max_dim_y": 0,
+            "max_value": "Not specified",
+            "min_alarm": "Not specified",
+            "min_value": "Not specified",
+            "name": "OtherAttribute",
+            "standard_unit": "No standard unit",
+            "unit": "",
+            "writable": "READ_WRITE",
+            "writable_attr_name": "logginglevel",
+          },
         ],
       "commands":
         [
@@ -76,6 +96,14 @@ DICT_A = """
             "dtype_in": "DevVoid",
             "dtype_out": "DevVoid",
             "name": "ClearTaskHistory_A",
+          },
+          {
+            "disp_level": "EXPERT",
+            "doc_in": "Uninitialised",
+            "doc_out": "Uninitialised",
+            "dtype_in": "DevVoid",
+            "dtype_out": "DevVoid",
+            "name": "OtherCommand",
           },
         ],
       "properties":
@@ -138,6 +166,26 @@ DICT_B = """
             "writable": "READ_WRITE",
             "writable_attr_name": "logginglevelelement",
           },
+          {
+            "data_format": "SCALAR",
+            "data_type": "DevLong",
+            "description": "Current  logging level to logging target for this device",
+            "disp_level": "OPERATOR",
+            "display_unit": "No display unit",
+            "format": "%d",
+            "label": "loggingLevel",
+            "max_alarm": "Not specified",
+            "max_dim_x": 1,
+            "max_dim_y": 0,
+            "max_value": "Not specified",
+            "min_alarm": "Not specified",
+            "min_value": "Not specified",
+            "name": "OtherAttribute",
+            "standard_unit": "No standard unit",
+            "unit": "",
+            "writable": "READ_WRITE",
+            "writable_attr_name": "logginglevel",
+          },
         ],
       "commands":
         [
@@ -164,6 +212,14 @@ DICT_B = """
             "dtype_in": "DevVoid",
             "dtype_out": "DevVoid",
             "name": "ClearTaskHistory_B",
+          },
+          {
+            "disp_level": "EXPERT",
+            "doc_in": "Uninitialised",
+            "doc_out": "Uninitialised",
+            "dtype_in": "DevVoid",
+            "dtype_out": "DevVoid",
+            "name": "OtherCommand",
           },
         ],
       "properties":
@@ -204,6 +260,9 @@ def test_validate():
         "\n\t\tspecification: OPERATOR_A, device: OPERATOR_B"
     ) in result
 
+    # Same in both
+    assert "OtherCommand" not in result
+
     assert (
         "Attribute differs, [loggingLevelElement_A] specified but missing in device"
     ) in result
@@ -215,6 +274,9 @@ def test_validate():
         )
     ) in result
 
+    # Same in both
+    assert "OtherAttribute" not in result
+
     assert (
         ("Property [ControlModeDefault_A] differs, specified but missing in device")
     ) in result
@@ -225,6 +287,9 @@ def test_validate():
             "not specified"
         )
     ) in result
+
+    # Same in both
+    assert "AdminModeDefault" not in result
 
     spec_dict = DICT_B
     dev_dict = DICT_A
@@ -245,6 +310,9 @@ def test_validate():
         "\n\t\tspecification: OPERATOR_B, device: OPERATOR_A"
     ) in result
 
+    # Same in both
+    assert "OtherCommand" not in result
+
     assert (
         "Attribute differs, [loggingLevelElement_B] specified but missing in device"
     ) in result
@@ -256,6 +324,8 @@ def test_validate():
         )
     ) in result
 
+    assert "OtherAttribute" not in result
+
     assert (
         ("Property [ControlModeDefault_B] differs, specified but missing in device")
     ) in result
@@ -266,3 +336,6 @@ def test_validate():
             "not specified"
         )
     ) in result
+
+    # Same in both
+    assert "AdminModeDefault" not in result

--- a/tango_simlib/utilities/tango_device_parser.py
+++ b/tango_simlib/utilities/tango_device_parser.py
@@ -57,7 +57,7 @@ class TangoDeviceParser(Parser):
                 "standard_unit": attribute.standard_unit,
                 "unit": attribute.unit,
                 "writable": str(attribute.writable),
-                "writable_attr_name": attribute.writable_attr_name
+                "writable_attr_name": attribute.writable_attr_name,
             }
             self.data_dict["meta"]["attributes"][attribute.name] = attr_data
 
@@ -148,3 +148,12 @@ class TangoDeviceParser(Parser):
     def get_device_cmd_override_metadata(self):
         """This method is not implemented"""
         raise NotImplementedError("get_device_cmd_override_metadata not implemented")
+
+    def get_parsed_data(self):
+        """Returns all the parsed data
+
+        Returns
+        -------
+        dict
+        """
+        return self.data_dict

--- a/tango_simlib/utilities/tango_device_parser.py
+++ b/tango_simlib/utilities/tango_device_parser.py
@@ -32,9 +32,9 @@ class TangoDeviceParser(Parser):
         Parameters
         ----------
         tango_device_name: str
-            Tango device name in the domain/family/member format
+            Tango device name in the domain/family/member format or the
+            FQDN tango://<TANGO_HOST>:<TANGO_PORT>/domain/family/member
         """
-        assert "TANGO_HOST" in os.environ, "TANGO_HOST env variable is not set"
         self.device_proxy = tango.DeviceProxy(tango_device_name)
         self.device_class_name = self.device_proxy.info().dev_class
 

--- a/tango_simlib/utilities/validate_device.py
+++ b/tango_simlib/utilities/validate_device.py
@@ -13,6 +13,14 @@ import yaml
 from tango_simlib.utilities.tango_device_parser import TangoDeviceParser
 from tango_simlib.tango_yaml_tools.base import TangoToYAML
 
+MINIMAL_SPEC_FORMAT = """
+class:
+meta:
+    attributes:
+    commands:
+    properties:
+"""
+
 
 def validate_device_from_url(tango_device_name, url_to_yaml_file, bidirectional):
     """Retrieves the YAML from the URL and checks conformance against the Tango device.
@@ -376,14 +384,6 @@ def check_property_differences(spec_properties, dev_properties, bidirectional):
 def validate_spec_structure(specification_yaml):
     """Make sure that the minimal specification structure is adhered to.
 
-    Minimal YAML format:
-
-        class:
-        meta:
-            attributes:
-            commands:
-            properties:
-
     Parameters
     ----------
     specification_yaml : str
@@ -402,11 +402,11 @@ def validate_spec_structure(specification_yaml):
                 passes = False
 
     if not passes:
-        minimal_format = """
-        class:
-        meta:
-            attributes:
-            commands:
-            properties:
-        """
-        assert 0, "Minimal structure not adhered to:\n{}".format(minimal_format)
+        assert 0, "Minimal structure not adhered to:\n{}".format(MINIMAL_SPEC_FORMAT)
+
+    for type_str in ["commands", "attributes", "properties"]:
+        if specification_data["meta"][type_str]:
+            for type_dict in specification_data["meta"][type_str]:
+                assert "name" in type_dict, "`name` field is required for all {}".format(
+                    type_str
+                )

--- a/tango_simlib/utilities/validate_device.py
+++ b/tango_simlib/utilities/validate_device.py
@@ -209,7 +209,7 @@ def check_list_dict_differences(spec_data, dev_data, type_str, bidirectional):
 
     Returns
     -------
-    list
+    issues : list
         A list of strings describing the issues, empty list for no issues
     """
     issues = []
@@ -251,7 +251,7 @@ def check_list_dict_differences(spec_data, dev_data, type_str, bidirectional):
 
 
 def check_single_dict_differences(spec, dev, type_str, bidirectional):
-    """Compare a single attribute/property
+    """Compare a single attribute/command
 
     Parameters
     ----------
@@ -281,7 +281,7 @@ def check_single_dict_differences(spec, dev, type_str, bidirectional):
 
     Returns
     -------
-    list
+    issues : list
         A list of strings describing the issues, empty list for no issues
     """
     assert spec["name"] == dev["name"]
@@ -351,7 +351,7 @@ def check_property_differences(spec_properties, dev_properties, bidirectional):
 
     Returns
     -------
-    list
+    issues : list
         A list of strings describing the issues, empty list for no issues
     """
     issues = []

--- a/tango_simlib/utilities/validate_device.py
+++ b/tango_simlib/utilities/validate_device.py
@@ -178,9 +178,9 @@ def check_data_differences(spec_data, dev_data, type_str):
     spec_data = sorted(spec_data, key=lambda i: i["name"])
     dev_data = sorted(dev_data, key=lambda i: i["name"])
 
+    # Check that the command/attribute names match
     spec_data_names = {i["name"] for i in spec_data}
     dev_data_names = {i["name"] for i in dev_data}
-
     if spec_data_names != dev_data_names:
         diff = spec_data_names.difference(dev_data_names)
         issues.append(
@@ -196,9 +196,11 @@ def check_data_differences(spec_data, dev_data, type_str):
             )
         )
 
-    mutual_command_names = spec_data_names.intersection(dev_data_names)
-    mutual_spec_data = filter(lambda x: x["name"] in mutual_command_names, spec_data)
-    mutual_dev_data = filter(lambda x: x["name"] in mutual_command_names, dev_data)
+    # Check that the commands/attributes that are in both the spec and device
+    # are the same
+    mutual_names = spec_data_names.intersection(dev_data_names)
+    mutual_spec_data = filter(lambda x: x["name"] in mutual_names, spec_data)
+    mutual_dev_data = filter(lambda x: x["name"] in mutual_names, dev_data)
 
     for spec, dev in zip(mutual_spec_data, mutual_dev_data):
         if spec != dev:

--- a/tango_simlib/utilities/validate_device.py
+++ b/tango_simlib/utilities/validate_device.py
@@ -23,7 +23,8 @@ def validate_device_from_url(tango_device_name, url_to_yaml_file, bidirectional)
         The URL to the specification file
 
     tango_device_name : str
-        Tango device name in the domain/family/member format
+        Tango device name in the domain/family/member format or the
+        FQDN tango://<TANGO_HOST>:<TANGO_PORT>/domain/family/member
 
     bidirectional: bool
         Whether to include details on the device that is not in the specification
@@ -49,7 +50,8 @@ def validate_device_from_path(tango_device_name, path_to_yaml_file, bidirectiona
         The path to the specification file
 
     tango_device_name : str
-        Tango device name in the domain/family/member format
+        Tango device name in the domain/family/member format or the
+        FQDN tango://<TANGO_HOST>:<TANGO_PORT>/domain/family/member
 
     bidirectional: bool
         Whether to include details on the device that is not in the specification
@@ -75,7 +77,8 @@ def get_device_specification(tango_device_name):
     Parameters
     ----------
     tango_device_name : str
-        Tango device name in the domain/family/member format
+        Tango device name in the domain/family/member format or the
+        FQDN tango://<TANGO_HOST>:<TANGO_PORT>/domain/family/member
 
     Returns
     -------
@@ -254,6 +257,9 @@ def check_single_dict_differences(spec, dev, type_str, bidirectional):
     type_str : str
         Either "Command" or "Attribute"
 
+    bidirectional: bool
+        Whether to include details on the device that is not in the specification
+
     Returns
     -------
     list
@@ -318,6 +324,9 @@ def check_property_differences(spec_properties, dev_properties, bidirectional):
              {'name': 'CentralLoggerEnabledDefault'},
              {'name': 'ConfigureTaskTimeout'},
              {'name': 'ControlModeDefault_B'}]
+
+    bidirectional: bool
+        Whether to include details on the device that is not in the specification
 
     Returns
     -------

--- a/tango_simlib/utilities/validate_device.py
+++ b/tango_simlib/utilities/validate_device.py
@@ -35,8 +35,9 @@ def validate_device_from_url(tango_device_name, url_to_yaml_file, bidirectional)
     """
     response = requests.get(url_to_yaml_file, allow_redirects=True)
     response.raise_for_status()
-    return compare_data(response.text, get_device_specification(tango_device_name),
-                        bidirectional)
+    return compare_data(
+        response.text, get_device_specification(tango_device_name), bidirectional
+    )
 
 
 def validate_device_from_path(tango_device_name, path_to_yaml_file, bidirectional):
@@ -63,8 +64,9 @@ def validate_device_from_path(tango_device_name, path_to_yaml_file, bidirectiona
     file_data = ""
     with open(str(file_path), "r") as data_file:
         file_data = data_file.read()
-    return compare_data(file_data, get_device_specification(tango_device_name),
-                        bidirectional)
+    return compare_data(
+        file_data, get_device_specification(tango_device_name), bidirectional
+    )
 
 
 def get_device_specification(tango_device_name):
@@ -126,7 +128,7 @@ def compare_data(specification_yaml, tango_device_yaml, bidirectional):
             specification_data["meta"]["commands"],
             tango_device_data["meta"]["commands"],
             "Command",
-            bidirectional
+            bidirectional,
         )
     )
 
@@ -136,7 +138,7 @@ def compare_data(specification_yaml, tango_device_yaml, bidirectional):
             specification_data["meta"]["attributes"],
             tango_device_data["meta"]["attributes"],
             "Attribute",
-            bidirectional
+            bidirectional,
         )
     )
 
@@ -145,7 +147,7 @@ def compare_data(specification_yaml, tango_device_yaml, bidirectional):
         check_property_differences(
             specification_data["meta"]["properties"],
             tango_device_data["meta"]["properties"],
-            bidirectional
+            bidirectional,
         )
     )
 
@@ -271,9 +273,7 @@ def check_single_dict_differences(spec, dev, type_str, bidirectional):
         if keys_not_in_spec:
             issues.append(
                 "{} [{}] differs, specification has keys [{}] but it's "
-                "not in device".format(
-                    type_str, spec["name"], ",".join(keys_not_in_spec)
-                )
+                "not in device".format(type_str, spec["name"], ",".join(keys_not_in_spec))
             )
 
         if keys_not_in_dev and bidirectional:
@@ -288,7 +288,7 @@ def check_single_dict_differences(spec, dev, type_str, bidirectional):
             if dev[key] != spec[key]:
                 issues.append("{} [{}] differs:".format(type_str, spec["name"]))
                 issues.append(
-                    "\t{}:\n\t\tspecification: {}, device: {}".format(
+                    "\t{}:\n\t\tspecification: {}\n\t\tdevice: {}".format(
                         key, spec[key], dev[key]
                     )
                 )

--- a/tango_simlib/utilities/validate_device.py
+++ b/tango_simlib/utilities/validate_device.py
@@ -32,8 +32,7 @@ def validate_device_from_url(tango_device_name, url_to_yaml_file):
     """
     response = requests.get(url_to_yaml_file, allow_redirects=True)
     response.raise_for_status()
-    content = response.content.decode(response.encoding)
-    return compare_data(content, get_device_specification(tango_device_name))
+    return compare_data(response.text, get_device_specification(tango_device_name))
 
 
 def validate_device_from_path(tango_device_name, path_to_yaml_file):
@@ -210,7 +209,7 @@ def check_list_dict_differences(spec_data, dev_data, type_str):
 
 
 def check_single_dict_differences(spec, dev, type_str):
-    """Compare a single atribute/property
+    """Compare a single attribute/property
 
     Parameters
     ----------

--- a/tango_simlib/utilities/validate_device.py
+++ b/tango_simlib/utilities/validate_device.py
@@ -120,6 +120,8 @@ def compare_data(specification_yaml, tango_device_yaml, bidirectional):
     tango_device_data = yaml.load(tango_device_yaml, Loader=yaml.FullLoader)
     if isinstance(specification_data, list):
         specification_data = specification_data[0]
+    if isinstance(tango_device_data, list):
+        tango_device_data = tango_device_data[0]
 
     issues = []
     if not specification_data["meta"]["commands"]:
@@ -389,6 +391,8 @@ def validate_spec_structure(specification_yaml):
         The specification in YAML format
     """
     specification_data = yaml.load(specification_yaml, Loader=yaml.FullLoader)
+    if isinstance(specification_data, list):
+        specification_data = specification_data[0]
 
     passes = True
     if "class" not in specification_data:

--- a/tango_simlib/utilities/validate_device.py
+++ b/tango_simlib/utilities/validate_device.py
@@ -172,7 +172,7 @@ def check_data_differences(spec_data, dev_data, type_str):
     Returns
     -------
     list
-        A list of strings describing the issues, if any
+        A list of strings describing the issues, empty list for no issues
     """
     issues = []
     spec_data = sorted(spec_data, key=lambda i: i["name"])
@@ -184,13 +184,15 @@ def check_data_differences(spec_data, dev_data, type_str):
     if spec_data_names != dev_data_names:
         diff = spec_data_names.difference(dev_data_names)
         issues.append(
-            "{} discrepancy, {} specified but missing in device".format(type_str, diff)
+            "{} discrepancy, [{}] specified but missing in device".format(
+                type_str, ",".join(diff)
+            )
         )
 
         diff = dev_data_names.difference(spec_data_names)
         issues.append(
-            "{} discrepancy, {} present in device but not specified".format(
-                type_str, diff
+            "{} discrepancy, [{}] present in device but not specified".format(
+                type_str, ",".join(diff)
             )
         )
 

--- a/tango_simlib/utilities/validate_device.py
+++ b/tango_simlib/utilities/validate_device.py
@@ -1,0 +1,211 @@
+#########################################################################################
+# Copyright 2020 SKA South Africa (http://ska.ac.za/)                                   #
+#                                                                                       #
+# BSD license - see LICENSE.txt for details                                             #
+#########################################################################################
+"""This module validates the conformance of a Tango device against a specification"""
+from pathlib import Path
+
+import requests
+
+import yaml
+
+from tango_simlib.utilities.tango_device_parser import TangoDeviceParser
+from tango_simlib.tango_yaml_tools.base import TangoToYAML
+
+
+def validate_device_from_url(tango_device_name, url_to_yaml_file):
+    """Retrieves the YAML from the URL and checks conformance against the Tango device.
+
+    Parameters
+    ----------
+    url_to_yaml_file : str
+        The URL to the specification file
+
+    tango_device_name : str
+        Tango device name in the domain/family/member format
+
+    Returns
+    -------
+    str
+        The validation result
+    """
+    response = requests.get(url_to_yaml_file, allow_redirects=True)
+    response.raise_for_status()
+    return validate_device(
+        yaml.load(response.content), get_device_specification(tango_device_name)
+    )
+
+
+def validate_device_from_path(tango_device_name, path_to_yaml_file):
+    """Retrieves the YAML from the file and checks conformance against the Tango device.
+
+    Parameters
+    ----------
+    path_to_yaml_file : str
+        The path to the specification file
+
+    tango_device_name : str
+        Tango device name in the domain/family/member format
+
+    Returns
+    -------
+    str
+        The validation result
+    """
+    file_path = Path(path_to_yaml_file)
+    assert file_path.is_file(), "{} is not a file".format(file_path)
+    file_data = ""
+    with open(str(file_path), "r") as data_file:
+        file_data = data_file.read()
+    return validate_device(
+        yaml.load(file_data), get_device_specification(tango_device_name)
+    )
+
+
+def get_device_specification(tango_device_name):
+    """Translate a device to YAML specification
+
+    Parameters
+    ----------
+    tango_device_name : str
+        Tango device name in the domain/family/member format
+
+    Returns
+    -------
+    str
+        The device specification in YAML format
+    """
+    parser = TangoToYAML(TangoDeviceParser)
+    return parser.build_yaml_from_device(tango_device_name)
+
+
+def validate_device(specification_yaml, tango_device_yaml):
+    """Check specification conformance against the Tango device.
+
+    Parameters
+    ----------
+    specification_yaml : str
+        The specification in YAML format
+
+    tango_device_yaml : str
+        The Tango device in YAML format
+
+    Returns
+    -------
+    str
+        The validation result
+    """
+    specification_data = yaml.load(specification_yaml, Loader=yaml.FullLoader)
+    tango_device_data = yaml.load(tango_device_yaml, Loader=yaml.FullLoader)
+    if isinstance(specification_data, list):
+        specification_data = specification_data[0]
+    if isinstance(tango_device_data, list):
+        tango_device_data = tango_device_data[0]
+
+    issues = []
+
+    if tango_device_data["class"] != specification_data["class"]:
+        issues.append(
+            "\nClass discrepancy, specified '{}', but device has '{}'".format(
+                specification_data["class"], tango_device_data["class"]
+            )
+        )
+
+    if issues:
+        issues.append("\n")
+    # Commands
+    issues.extend(
+        check_data_differences(
+            specification_data["meta"]["commands"],
+            tango_device_data["meta"]["commands"],
+            "Command",
+        )
+    )
+
+    if issues:
+        issues.append("\n")
+    # Attributes
+    issues.extend(
+        check_data_differences(
+            specification_data["meta"]["attributes"],
+            tango_device_data["meta"]["attributes"],
+            "Attribute",
+        )
+    )
+
+    return "\n".join(issues)
+
+
+def check_data_differences(spec_data, dev_data, type_str):
+    """Compare Commands and Attributes in the YAML specification
+
+    Parameters
+    ----------
+    spec_data : list
+        List of dictionaries with specification data
+        E.g [
+                {'disp_level': 'OPERATOR',
+                 'doc_in': 'ON/OFF',
+                 'doc_out': 'Uninitialised',
+                 'dtype_in': 'DevBoolean',
+                 'dtype_out': 'DevVoid',
+                 'name': 'Capture'},
+                 ...
+            ]
+
+    dev_data : list
+        List of dictionaries with specification data
+        E.g [
+                {'disp_level': 'OPERATOR',
+                 'doc_in': 'ON/OFF',
+                 'doc_out': 'Uninitialised',
+                 'dtype_in': 'DevBoolean',
+                 'dtype_out': 'DevVoid',
+                 'name': 'Capture'},
+                 ...
+            ]
+
+    type_str : str
+        Either "Command" or "Attribute"
+
+    Returns
+    -------
+    list
+        A list of strings describing the issues, if any
+    """
+    issues = []
+    spec_data = sorted(spec_data, key=lambda i: i["name"])
+    dev_data = sorted(dev_data, key=lambda i: i["name"])
+
+    spec_data_names = {i["name"] for i in spec_data}
+    dev_data_names = {i["name"] for i in dev_data}
+
+    if spec_data_names != dev_data_names:
+        diff = spec_data_names.difference(dev_data_names)
+        issues.append(
+            "{} discrepancy, {} specified but missing in device".format(type_str, diff)
+        )
+
+        diff = dev_data_names.difference(spec_data_names)
+        issues.append(
+            "{} discrepancy, {} present in device but not specified".format(
+                type_str, diff
+            )
+        )
+
+    mutual_command_names = spec_data_names.intersection(dev_data_names)
+    mutual_spec_data = filter(lambda x: x["name"] in mutual_command_names, spec_data)
+    mutual_dev_data = filter(lambda x: x["name"] in mutual_command_names, dev_data)
+
+    for spec, dev in zip(mutual_spec_data, mutual_dev_data):
+        if spec != dev:
+            issues.append("{} details differ for {}:".format(type_str, spec["name"]))
+            for key in spec.keys():
+                if dev[key] != spec[key]:
+                    issues.append(
+                        "\t{}:\n\t\tspecification: {}, device: {}".format(
+                            key, spec[key], dev[key]
+                        )
+                    )
+    return issues

--- a/tango_simlib/utilities/validate_device.py
+++ b/tango_simlib/utilities/validate_device.py
@@ -32,7 +32,7 @@ def validate_device_from_url(tango_device_name, url_to_yaml_file):
     """
     response = requests.get(url_to_yaml_file, allow_redirects=True)
     response.raise_for_status()
-    return validate_device(
+    return compare_data(
         yaml.load(response.content), get_device_specification(tango_device_name)
     )
 
@@ -58,9 +58,7 @@ def validate_device_from_path(tango_device_name, path_to_yaml_file):
     file_data = ""
     with open(str(file_path), "r") as data_file:
         file_data = data_file.read()
-    return validate_device(
-        yaml.load(file_data), get_device_specification(tango_device_name)
-    )
+    return compare_data(yaml.load(file_data), get_device_specification(tango_device_name))
 
 
 def get_device_specification(tango_device_name):
@@ -80,8 +78,8 @@ def get_device_specification(tango_device_name):
     return parser.build_yaml_from_device(tango_device_name)
 
 
-def validate_device(specification_yaml, tango_device_yaml):
-    """Check specification conformance against the Tango device.
+def compare_data(specification_yaml, tango_device_yaml):
+    """Compare 2 sets of YAML built from the specification and from the device
 
     Parameters
     ----------
@@ -136,6 +134,7 @@ def validate_device(specification_yaml, tango_device_yaml):
 
     if issues:
         issues.append("\n")
+    # Properties
     issues.extend(
         check_property_differences(
             specification_data["meta"]["properties"],

--- a/tango_simlib/utilities/validate_device.py
+++ b/tango_simlib/utilities/validate_device.py
@@ -32,9 +32,8 @@ def validate_device_from_url(tango_device_name, url_to_yaml_file):
     """
     response = requests.get(url_to_yaml_file, allow_redirects=True)
     response.raise_for_status()
-    return compare_data(
-        yaml.load(response.content), get_device_specification(tango_device_name)
-    )
+    content = response.content.decode(response.encoding)
+    return compare_data(content, get_device_specification(tango_device_name))
 
 
 def validate_device_from_path(tango_device_name, path_to_yaml_file):
@@ -58,7 +57,7 @@ def validate_device_from_path(tango_device_name, path_to_yaml_file):
     file_data = ""
     with open(str(file_path), "r") as data_file:
         file_data = data_file.read()
-    return compare_data(yaml.load(file_data), get_device_specification(tango_device_name))
+    return compare_data(file_data, get_device_specification(tango_device_name))
 
 
 def get_device_specification(tango_device_name):
@@ -103,6 +102,7 @@ def compare_data(specification_yaml, tango_device_yaml):
 
     issues = []
 
+    # Class
     if tango_device_data["class"] != specification_data["class"]:
         issues.append(
             "\nClass differs, specified '{}', but device has '{}'".format(
@@ -110,8 +110,6 @@ def compare_data(specification_yaml, tango_device_yaml):
             )
         )
 
-    if issues:
-        issues.append("\n")
     # Commands
     issues.extend(
         check_list_dict_differences(
@@ -121,8 +119,6 @@ def compare_data(specification_yaml, tango_device_yaml):
         )
     )
 
-    if issues:
-        issues.append("\n")
     # Attributes
     issues.extend(
         check_list_dict_differences(
@@ -132,8 +128,6 @@ def compare_data(specification_yaml, tango_device_yaml):
         )
     )
 
-    if issues:
-        issues.append("\n")
     # Properties
     issues.extend(
         check_property_differences(

--- a/tango_simlib/utilities/validate_device.py
+++ b/tango_simlib/utilities/validate_device.py
@@ -7,11 +7,10 @@
 from pathlib import Path
 
 import requests
-
 import yaml
 
-from tango_simlib.utilities.tango_device_parser import TangoDeviceParser
 from tango_simlib.tango_yaml_tools.base import TangoToYAML
+from tango_simlib.utilities.tango_device_parser import TangoDeviceParser
 
 MINIMAL_SPEC_FORMAT = """
 class:
@@ -221,7 +220,7 @@ def check_list_dict_differences(spec_data, dev_data, type_str, bidirectional):
     if spec_data_names != dev_data_names:
         diff = spec_data_names.difference(dev_data_names)
         if diff:
-            diff = sorted(list(diff))
+            diff = sorted(diff)
             issues.append(
                 "{} differs, [{}] specified but missing in device".format(
                     type_str, ",".join(diff)
@@ -231,7 +230,7 @@ def check_list_dict_differences(spec_data, dev_data, type_str, bidirectional):
         if bidirectional:
             diff = dev_data_names.difference(spec_data_names)
             if diff:
-                diff = sorted(list(diff))
+                diff = sorted(diff)
                 issues.append(
                     "{} differs, [{}] present in device but not specified".format(
                         type_str, ",".join(diff)
@@ -295,14 +294,14 @@ def check_single_dict_differences(spec, dev, type_str, bidirectional):
         mutual_keys = spec_keys.intersection(dev_keys)
 
         if keys_not_in_spec:
-            keys_not_in_spec = sorted(list(keys_not_in_spec))
+            keys_not_in_spec = sorted(keys_not_in_spec)
             issues.append(
                 "{} [{}] differs, specification has keys [{}] but it's "
                 "not in device".format(type_str, spec["name"], ",".join(keys_not_in_spec))
             )
 
         if keys_not_in_dev and bidirectional:
-            keys_not_in_dev = sorted(list(keys_not_in_dev))
+            keys_not_in_dev = sorted(keys_not_in_dev)
             issues.append(
                 "{} [{}] differs, device has keys [{}] but it's "
                 "not in the specification".format(
@@ -361,7 +360,7 @@ def check_property_differences(spec_properties, dev_properties, bidirectional):
     if spec_props != dev_props:
         diff = spec_props.difference(dev_props)
         if diff:
-            diff = sorted(list(diff))
+            diff = sorted(diff)
             issues.append(
                 "Property [{}] differs, specified but missing in device".format(
                     ",".join(diff)
@@ -371,7 +370,7 @@ def check_property_differences(spec_properties, dev_properties, bidirectional):
         if bidirectional:
             diff = dev_props.difference(spec_props)
             if diff:
-                diff = sorted(list(diff))
+                diff = sorted(diff)
                 issues.append(
                     "Property [{}] differs, present in device but not specified".format(
                         ",".join(diff)


### PR DESCRIPTION
Added the ability to `tango-yaml` that can check the conformance of a Tango device against a specification.

```
tango-yaml validate -h
usage: tango_yaml validate [-h] (-url URL | -path PATH) [-bidirectional]
                           tango_device_name

positional arguments:
  tango_device_name  Tango device name in the format domain/family/member.
                     TANGO_HOST env variable has to be set

optional arguments:
  -h, --help         show this help message and exit
  -url URL           The URL to a YAML specification file
  -path PATH         The file path to a YAML specification file
  -bidirectional     When bidirectional is included, any details on the device
                     that is not in the spec is also listed.
```
See the changes in intro.rst for sample output

JIRA: [SAR-113](https://jira.skatelescope.org/browse/SAR-113)


