### PR TITLE
Prepare for 0.7.0 release

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -10,6 +10,15 @@
 .. _117: https://github.com/ska-sa/tango-simlib/pull/117
 .. _118: https://github.com/ska-sa/tango-simlib/pull/118
 .. _119: https://github.com/ska-sa/tango-simlib/pull/119
+.. _121: https://github.com/ska-sa/tango-simlib/pull/121
+.. _122: https://github.com/ska-sa/tango-simlib/pull/122
+
+0.7.0
+-----
+- Updated CHANGELOG in 122_
+- Added `validate` option to `tango-yaml` tool in 121_
+    - This sub command enables conformance verification of a running Tango
+      device against a specification file.
 
 0.6.0
 -----

--- a/README.rst
+++ b/README.rst
@@ -98,17 +98,19 @@ After installing tango_simlib, the ``tango-yaml`` script will be available to us
 
     $ tango-yaml -h
 
-    usage: tango_yaml [-h] {xmi,fandango,tango_device} ...
+    usage: tango_yaml [-h] {xmi,fandango,tango_device,validate} ...
 
     This program translates various file formats that describe Tango devices to
-    YAML
+    YAML. Or validates the conformance of a device against a specification.
 
     positional arguments:
-    {xmi,fandango,tango_device}
+    {xmi,fandango,tango_device,validate}
                             sub command help
         xmi                 Build YAML from a XMI file
         fandango            Build YAML from a fandango file
         tango_device        Build YAML from a running Tango device
+        validate            Check conformance of a Tango device against a
+                            specification in YAML format
 
     optional arguments:
     -h, --help            show this help message and exit


### PR DESCRIPTION
Updated CHANGELOG and README for 0.7.0 release.

Latest readthedocs build here: [here](https://readthedocs.org/projects/tango-simlib/builds/11404282/)

Passing master build [here](http://ci.camlab.kat.ac.za/job/tango_simlib-multibranch/job/master/39/)

Python2/3 build and install test run:

```
python3 setup.py sdist bdist_wheel
/usr/lib/python3.6/distutils/dist.py:261: UserWarning: Unknown distribution option: 'home_page'
  warnings.warn(msg)
running sdist
running egg_info
writing tango_simlib.egg-info/PKG-INFO
writing dependency_links to tango_simlib.egg-info/dependency_links.txt
writing entry points to tango_simlib.egg-info/entry_points.txt
...

python2 setup.py sdist bdist_wheel
/usr/lib/python2.7/distutils/dist.py:267: UserWarning: Unknown distribution option: 'home_page'
  warnings.warn(msg)
running sdist
running egg_info
writing requirements to tango_simlib.egg-info/requires.txt
writing tango_simlib.egg-info/PKG-INFO
writing top-level names to tango_simlib.egg-info/top_level.txt
writing dependency_links to tango_simlib.egg-info/dependency_links.txt
writing entry points to tango_simlib.egg-info/entry_points.txt
....

pip2 uninstall tango-simlib
Uninstalling tango-simlib-0.6.1.dev865+master.45d50b7:
  /usr/local/bin/DishElementMaster-DS
  /usr/local/bin/Weather-DS
  /usr/local/bin/tango-simlib-generator
  /usr/local/bin/tango-simlib-launcher
....

pip2 install ./dist/tango_simlib-0.6.1.dev865+master.45d50b7-py2-none-any.whl
Processing ./dist/tango_simlib-0.6.1.dev865+master.45d50b7-py2-none-any.whl
Requirement already satisfied: numpy in /usr/local/lib/python2.7/dist-packages (from tango-simlib==0.6.1.dev865+master.45d50b7)
Requirement already satisfied: PyTango>=9.2.2 in /usr/lib/python2.7/dist-packages (from tango-simlib==0.6.1.dev865+master.45d50b7)
...
Successfully installed tango-simlib-0.6.1.dev865+master.45d50b7

pip3 uninstall tango-simlib
WARNING: Skipping tango-simlib as it is not installed.

pip3 install ./dist/tango_simlib-0.6.1.dev865+master.45d50b7-py3-none-any.whl 
Looking in indexes: http://pypi.camlab.kat.ac.za/pypi/trusty
Processing ./dist/tango_simlib-0.6.1.dev865+master.45d50b7-py3-none-any.whl
Requirement already satisfied: jsonschema in /usr/local/lib/python3.6/dist-packages (from tango-simlib==0.6.1.dev865+master.45d50b7) (3.2.0)
...
Installing collected packages: tango-simlib
Successfully installed tango-simlib-0.6.1.dev865+master.45d50b7

```