### PR TITLE
Pinned last known compatible Py2 version of `pyrsistent`.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -50,6 +50,8 @@ setup(
     install_requires=[
         "future",
         "futures; python_version<'3'",
+        "pyrsistent==0.16.0; python_version<'3'",
+        "pyrsistent; python_version>='3'",
         "jsonschema",
         "numpy",
         "PyTango>=9.2.2",


### PR DESCRIPTION
This PR does the following:
- Pins `pyrsistent` to last known compatible Python2  version, while allowing Python3 to install the latest.

See: http://ci.camlab.kat.ac.za/job/ci.pin-dependencies/349/console