### PR TITLE
Allow min_update_period to be overridden

### DIFF
--- a/doc/intro.rst
+++ b/doc/intro.rst
@@ -130,9 +130,24 @@ in turn start up the device server process, all in one go.
     $ tango-simlib-launcher --name mkat_sim/weather/1 --class Weather\
                             --name mkat_simcontrol/weather/1\
                             --class WeatherSimControl\
-                            --server-command weather-DS --port 0\
+                            --server-command ./weather-DS --port 0\
                             --server-instance tango-launched\
                             --put-device-property mkat_simcontrol/weather/1:model_key:mkat_sim/weather/1
+
+The simulator limits the rate of calls to the internal model ``update`` method.  The default is
+0.99 seconds. This can be overridden via the ``min_update_period`` property on the main device.
+For example, we can reduce it to 0.5 seconds by adding the last argument below.
+
+.. code-block:: bash
+
+    $ tango-simlib-launcher --name mkat_sim/weather/1 --class Weather\
+                            --name mkat_simcontrol/weather/1\
+                            --class WeatherSimControl\
+                            --server-command ./weather-DS --port 0\
+                            --server-instance tango-launched\
+                            --put-device-property mkat_simcontrol/weather/1:model_key:mkat_sim/weather/1\
+                            --put-device-property mkat_sim/weather/1:min_update_period:0.5
+
 
 Ready-made Simulators
 ---------------------

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -32,7 +32,7 @@ from tango import (
     DevState,
     UserDefaultAttrProp,
 )
-from tango.server import Device, DeviceMeta, attribute, device_property
+from tango.server import Device, attribute, device_property
 from tango_simlib.model import (
     INITIAL_CONSTANT_VALUE_TYPES,
     Model,

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -32,7 +32,7 @@ from tango import (
     DevState,
     UserDefaultAttrProp,
 )
-from tango.server import Device, DeviceMeta, attribute
+from tango.server import Device, DeviceMeta, attribute, device_property
 from tango_simlib.model import (
     INITIAL_CONSTANT_VALUE_TYPES,
     Model,
@@ -254,12 +254,19 @@ def get_tango_device_server(models, sim_data_files):
     class TangoDeviceServer(TangoDeviceServerBase, TangoDeviceServerStaticAttrs):
         _models = models
 
+        min_update_period = device_property(
+            dtype=float,
+            default_value=0.99,
+            doc="Minimum time before model update method can be called again [seconds].",
+        )
+
         def init_device(self):
             super(TangoDeviceServer, self).init_device()
             self.model = self._models[self.get_name()]
             self._not_added_attributes = []
             write_device_properties_to_db(self.get_name(), self.model)
             self.model.reset_model_state()
+            self.model.min_update_period = self.min_update_period
             self.initialize_dynamic_commands()
 
         def initialize_dynamic_commands(self):


### PR DESCRIPTION
This allows the default minimum update period to be overridden via a property. It can be set when launching the device from the command line.

Not sure how to make a test for this, so here's an example of the reduced update period for the katsim dish simulator.   Note that calls to [pre_update](https://github.com/ska-sa/katsim/blob/01c19ba9b60f98bcbc01915d24635c9526173731/katsim/ska_mpi_dsh_lmc_override.py#L511) depend on client access to the device, so it is not regular.  However, we can see that the times are now close to 0.2 seconds instead of the default 0.99 seconds.  Scroll all the way to right to see the new argument:
`--put-device-property mid_dish_0026/elt/master:min_update_period:0.2`
```
$ kat-tango-sim-launcher.py --name mid_dish_0026/elt/master --class DishElementMaster --name mid_dish_0026sim/elt/master --class DishElementMasterSimControl --server-command DishElementMaster --server-instance mid_dish_0026 --port 4052 --file-name katconfig/static/antennas/s0026_sim.conf --put-device-property mid_dish_0026sim/elt/master:model_key:mid_dish_0026/elt/master --put-device-property mid_dish_0026/elt/master:min_update_period:0.2
Setting device 'mid_dish_0026/elt/master' property 'min_update_period': '0.2'
Setting device 'mid_dish_0026sim/elt/master' property 'model_key': 'mid_dish_0026/elt/master'
Starting TANGO device server:
'DishElementMaster' 'mid_dish_0026' '-ORBendPoint' 'giop:tcp::4052' '-file=/tmp/tmpzk3FX3'
Can't create notifd event supplier. Notifd event not available
Ready to accept request
pre_update called - dt 0.861226081848
pre_update called - dt 0.399704933167
...
pre_update called - dt 0.200511932373
pre_update called - dt 0.800007104874
...
pre_update called - dt 0.202538013458
pre_update called - dt 0.207702875137
pre_update called - dt 0.799002170563
```

JIRA (SKA):  [SAR-155](https://jira.skatelescope.org/browse/SAR-155)