### PR TITLE
Set the default device state from the simulator data description file(s)

### DIFF
--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -287,7 +287,7 @@ def get_tango_device_server(models, sim_data_files):
             # Only the .fgo file has the State as an attribute. The .xmi files has it as
             # a command, so it won't have an initial value. And in some other data
             # description files the State attribute is not specified.
-            if self.model.sim_quantities.has_key("State"):
+            if "State" in self.model.sim_quantities:
                 # Set default device state
                 state_quantity = self.model.sim_quantities["State"].meta
                 state_value = int(state_quantity["value"])

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -284,10 +284,14 @@ def get_tango_device_server(models, sim_data_files):
             self.model.min_update_period = self.min_update_period
             self.initialize_dynamic_commands()
 
-            # Set default device state
-            state_quantity = self.model.sim_quantities["State"].meta
-            state_value = int(state_quantity["value"])
-            self.set_state(DevState.values[state_value])
+            # Only the .fgo file has the State as an attribute. The .xmi files has it as
+            # a command, so it won't have an initial value. And in some other data
+            # description files the State attribute is not specified.
+            if self.model.sim_quantities.has_key("State"):
+                # Set default device state
+                state_quantity = self.model.sim_quantities["State"].meta
+                state_value = int(state_quantity["value"])
+                self.set_state(DevState.values[state_value])
 
         def initialize_dynamic_commands(self):
             for action_name, action_handler in self.model.sim_actions.items():

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -285,7 +285,7 @@ def get_tango_device_server(models, sim_data_files):
             self.initialize_dynamic_commands()
 
             # Set default device state
-            state_quantity = self.model.sim_quantities["State"]
+            state_quantity = self.model.sim_quantities["State"].meta
             state_value = int(state_quantity["value"])
             self.set_state(state_value)
 

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -284,6 +284,11 @@ def get_tango_device_server(models, sim_data_files):
             self.model.min_update_period = self.min_update_period
             self.initialize_dynamic_commands()
 
+            # Set default device state
+            state_quantity = self.model.sim_quantities["State"]
+            state_value = int(state_quantity["value"])
+            self.set_state(state_value)
+
         def initialize_dynamic_commands(self):
             for action_name, action_handler in self.model.sim_actions.items():
                 cmd_handler = helper_module.generate_cmd_handler(

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -287,7 +287,7 @@ def get_tango_device_server(models, sim_data_files):
             # Set default device state
             state_quantity = self.model.sim_quantities["State"].meta
             state_value = int(state_quantity["value"])
-            self.set_state(state_value)
+            self.set_state(DevState.values[state_value])
 
         def initialize_dynamic_commands(self):
             for action_name, action_handler in self.model.sim_actions.items():


### PR DESCRIPTION
Previously the `dev_state` was set to `DevState.ON` by default when the device starts up. This change allows it to be configurable using the simulator data description files.


*Screenshots or code snippets (if appropriate):*

N/A

*Definition of Done Checklist*

- [x] Code meets our [python style guidelines](https://docs.google.com/document/d/1aZoIyR9tz5rCWr2qJKuMTmKp2IzHlFjrCFrpDDHFypM/edit?usp=sharing)?
- [x] Unit tested (coded, passed, included)?
- [x] Requested at least 2 reviewers?
- [x] Commented code, particularly in hard-to-understand areas?
- [x] Made corresponding changes to the documentation (e.g. Python documentation, System Engineering Documentation, version description updates, README file, etc)?

JIRA (SKA): [SKB-42](https://skaafrica.atlassian.net/browse/SKB-42)
