### PR TITLE
Reduce the noisy logging in the tango device

### DIFF
--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -92,7 +92,6 @@ class TangoDeviceServerBase(Device):
         if self.get_state() != DevState.OFF:
             name = attr.get_name()
             data = attr.get_write_value()
-            MODULE_LOGGER.info("Writing value %s to attribute '%s'." % (data, name))
             self.model.sim_quantities[name].set_val(data, self.model.time_func())
 
 
@@ -164,9 +163,6 @@ def add_static_attribute(tango_device_class, attr_name, attr_meta):
             # to return the string value corresponding to the respective enum value
             # since an integer value is returned by device server when
             # attribute value is read
-            MODULE_LOGGER.info(
-                "Writing value {} to attribute '{}'.".format(new_val, attr_name)
-            )
             _sim_quantities = tango_device_instance.model.sim_quantities
             tango_device_instance.model_quantity = _sim_quantities[attr_name]
             tango_device_instance.model_quantity.set_val(
@@ -411,7 +407,7 @@ def get_tango_device_server(models, sim_data_files):
 
         @attribute(
             dtype=int,
-            doc="Number of attributes not added to the device due " "to an error.",
+            doc="Number of attributes not added to the device due to an error.",
         )
         def NumAttributesNotAdded(self):
             return len(self._not_added_attributes)


### PR DESCRIPTION
This usually occurs in the attribute's write methods. If the attribute gets written frequently it results in a lot of noise in the logs.

*Screenshots or code snippets (if appropriate):*

![Screenshot from 2021-05-20 15-57-39](https://user-images.githubusercontent.com/16665803/118994455-a4687f00-b986-11eb-8272-7c55cd406771.png)

*Definition of Done Checklist*

- [x] Code meets our [python style guidelines](https://docs.google.com/document/d/1aZoIyR9tz5rCWr2qJKuMTmKp2IzHlFjrCFrpDDHFypM/edit?usp=sharing)?
- [x] Unit tested (coded, passed, included)?
- [ ] Requested at least 2 reviewers?
- [x] Commented code, particularly in hard-to-understand areas?
- [x] Made corresponding changes to the documentation (e.g. Python documentation, System Engineering Documentation, version description updates, README file, etc)?

(SKA) JIRA: [SAR-233](https://jira.skatelescope.org/browse/SAR-233)
