### PR TITLE
Updated the docker image used by the github actions workflow

### DIFF
--- a/.github/workflows/unit_tests.yaml
+++ b/.github/workflows/unit_tests.yaml
@@ -5,7 +5,7 @@ jobs:
   testing:
     runs-on: ubuntu-latest
     container:
-      image: nexus.engageska-portugal.pt/ska-docker/ska-python-buildenv:9.3.3.1
+      image: artefact.skao.int/ska-tango-images-pytango-builder:9.3.10
     steps:
       - uses: actions/checkout@v1
       - name: Install flake8


### PR DESCRIPTION
SKA has moved to a new central artefact repository, https://artefact.skatelescope.org. We need to pull the docker image used for testing from that repository.

*Screenshots or code snippets (if appropriate):*
N/A

*Definition of Done Checklist*

- [ ] ~Code meets our [python style guidelines](https://docs.google.com/document/d/1aZoIyR9tz5rCWr2qJKuMTmKp2IzHlFjrCFrpDDHFypM/edit?usp=sharing)?~
- [ ] ~Unit tested (coded, passed, included)?~
- [x] Requested at least 2 reviewers?
- [ ] ~Commented code, particularly in hard-to-understand areas?~
- [ ] ~Made corresponding changes to the documentation (e.g. Python documentation, System Engineering Documentation, version description updates, README file, etc)?~

JIRA: [N/A](https://skaafrica.atlassian.net/browse/JIRA_ISSUE_NUMBER)
