### PR TITLE
Only install jsonschema 3.2 for python2

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -52,7 +52,7 @@ setup(
         "futures; python_version<'3'",
         "pyrsistent==0.16.0; python_version<'3'",
         "pyrsistent; python_version>='3'",
-        "jsonschema==3.2.0",
+        "jsonschema==3.2.0; python_version<'3'",
         "jsonschema; python_version>='3'",
         "numpy",
         "PyTango>=9.2.2",


### PR DESCRIPTION
This PR is linked to https://github.com/ska-sa/tango-simlib/pull/143.
Motivation for thus PR is based on https://github.com/ska-sa/tango-simlib/pull/143#discussion_r730828080