### PR TITLE
Updated the class instance prefix to be more definitive

### DIFF
--- a/tango_simlib/model.py
+++ b/tango_simlib/model.py
@@ -546,7 +546,7 @@ class PopulateModelActions(object):
         # Need to override the model's update method if the override class provides one.
         instance = []
         for instance_ in instances:
-            if instance_.startswith("Sim"):
+            if instance_.startswith("Sim_"):
                 instance.append(instances[instance_])
 
         for inst in instance:

--- a/tango_simlib/model.py
+++ b/tango_simlib/model.py
@@ -588,7 +588,7 @@ class PopulateModelActions(object):
             if cmd_name.startswith("test_"):
                 cmd_name = cmd_name.split("test_")[1]
                 for instance_ in instances:
-                    if instance_.startswith("SimControl"):
+                    if instance_.startswith("SimControl_"):
                         instance = instances[instance_]
                 self._check_override_action_presence(cmd_name, instance, "test_action_{}")
                 handler = getattr(
@@ -601,7 +601,7 @@ class PopulateModelActions(object):
                 self.sim_model.set_test_sim_action(cmd_name, handler)
             else:
                 for instance_ in instances:
-                    if instance_.startswith("Sim"):
+                    if instance_.startswith("Sim_"):
                         instance = instances[instance_]
                 self._check_override_action_presence(cmd_name, instance, "action_{}")
                 handler = getattr(

--- a/tango_simlib/tests/test_sim_test_interface.py
+++ b/tango_simlib/tests/test_sim_test_interface.py
@@ -394,7 +394,7 @@ class test_TangoSimGenDeviceIntegration(ClassCleanupUnittestMixin, unittest.Test
             set(),
             "The device has commands meant for the test sim control device.",
         )
- 
+
     def test_sim_device_Add_command(self):
         command_name = "Add"
         expected_value = 5

--- a/tango_simlib/tests/test_sim_test_interface.py
+++ b/tango_simlib/tests/test_sim_test_interface.py
@@ -394,6 +394,15 @@ class test_TangoSimGenDeviceIntegration(ClassCleanupUnittestMixin, unittest.Test
             set(),
             "The device has commands meant for the test sim control device.",
         )
+ 
+    def test_sim_device_Add_command(self):
+        command_name = "Add"
+        expected_value = 5
+        actual_value = self.sim_device.command_inout(command_name, [3, 2])
+        time.sleep(1)
+        self.assertEqual(
+            expected_value,
+            actual_value)
 
     def test_StopRainfall_command(self):
         command_name = "StopRainfall"


### PR DESCRIPTION
When the `startswith` method is called with the  prefix 'Sim' it resulted to `True` for 'SimControl'. This results in the action handlers in `sim_actions` not getting overridden with the correct `action_handler` as it is not defined in the provided 'SimControl' class.
This is why only one of the devices' commands where getting overridden.

I also added a test just to make sure that we can execute commands in both the simulator and the simulator controller.

Signed-off-by: Katleho Madisa <katleho.madisa47@gmail.com>

*Screenshots or code snippets (if appropriate):*
- N/A

*Definition of Done Checklist*

- [x] Code meets our [python style guidelines](https://docs.google.com/document/d/1aZoIyR9tz5rCWr2qJKuMTmKp2IzHlFjrCFrpDDHFypM/edit?usp=sharing)?
- [x] Unit tested (coded, passed, included)?
- [x] Requested at least 2 reviewers?
- [x] Commented code, particularly in hard-to-understand areas?
- [x] Made corresponding changes to the documentation (e.g. Python documentation, System Engineering Documentation, version description updates, README file, etc)?

JIRA: [N/A](https://skaafrica.atlassian.net/browse/JIRA_ISSUE_NUMBER)
