### PR TITLE
SAR-393 Added a release note for version 0.9.3

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -22,6 +22,15 @@
 .. _133: https://github.com/ska-sa/tango-simlib/pull/133
 .. _135: https://github.com/ska-sa/tango-simlib/pull/135
 .. _138: https://github.com/ska-sa/tango-simlib/pull/138
+.. _143: https://github.com/ska-sa/tango-simlib/pull/143
+.. _146: https://github.com/ska-sa/tango-simlib/pull/146
+.. _148: https://github.com/ska-sa/tango-simlib/pull/148
+
+0.9.3
+-----
+- Reduce logs spewed by device servers 148_.
+- Updated class instance prefix to be more definitive 146_.
+- Pinned jsonschema package to py2 compatible version 143_.
 
 0.9.2
 -----


### PR DESCRIPTION
Updated the CHANGELOG for release `0.9.3`.

JIRA (SKA): [SAR-393](https://jira.skatelescope.org/browse/SAR-393)
