### PR TITLE
SAR-393 Reduce more logs spewed out

### DIFF
--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -173,7 +173,7 @@ def add_static_attribute(tango_device_class, attr_name, attr_meta):
     # Add the read method and the attribute to the class object
     setattr(tango_device_class, read_meth.__name__, read_meth)
     setattr(tango_device_class, attr.__name__, attr)
-    MODULE_LOGGER.info("Adding static attribute {} to the device.".format(attr_name))
+    MODULE_LOGGER.debug("Adding static attribute {} to the device.".format(attr_name))
 
 
 def _create_sim_test_interface_atttribute(models, class_instance):


### PR DESCRIPTION
This change reduces the number of log entries made per attribute created in the device server. So instead of logging for each attribute created, I group those attribute into one log message. See screenshot below.

*Screenshots or code snippets (if appropriate):*
![Screenshot from 2022-06-09 15-16-49](https://user-images.githubusercontent.com/16665803/172856457-b282ddda-1f1f-474f-9403-e216e5ced2de.png)

*Definition of Done Checklist*

- [ ] Code meets our [python style guidelines](https://docs.google.com/document/d/1aZoIyR9tz5rCWr2qJKuMTmKp2IzHlFjrCFrpDDHFypM/edit?usp=sharing)?
- [ ] Unit tested (coded, passed, included)?
- [ ] Requested at least 2 reviewers?
- [ ] Commented code, particularly in hard-to-understand areas?
- [ ] Made corresponding changes to the documentation (e.g. Python documentation, System Engineering Documentation, version description updates, README file, etc)?

JIRA: [JIRA_ISSUE_NUMBER](https://skaafrica.atlassian.net/browse/JIRA_ISSUE_NUMBER)
