### PR TITLE
Pin PyTango to avoid failures relating to wheel building during installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -55,7 +55,7 @@ setup(
         "jsonschema==3.2.0; python_version<'3'",
         "jsonschema; python_version>='3'",
         "numpy",
-        "PyTango>=9.2.2",
+        "PyTango==9.3.3",
         "pathlib",
         "pyyaml",
     ],


### PR DESCRIPTION
This PR does the following:
- Pins PyTango (9.3.3) which is the last known version that doesn't fail during installation due to pip-wheel building.


![image](https://user-images.githubusercontent.com/7910856/174968161-f7fd5298-00f2-4a4a-9e32-8e9a0c5e3f36.png)


JIRA: [MT-2980](https://skaafrica.atlassian.net/browse/MT-2980)
