### PR TITLE
#153 Support IMAGE attribute addition

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -9,4 +9,6 @@ include tango_simlib/tests/config_files/devenum_test_case.xmi
 include tango_simlib/tests/config_files/DishElementMaster.xmi
 include tango_simlib/tests/config_files/DishElementMaster_SimDD.json
 include tango_simlib/tests/config_files/database2.fgo
+include tango_simlib/tests/config_files/Spectrum_Image.fgo
+include tango_simlib/tests/config_files/Spectrum_Simdd.json
 include CHANGELOG.rst

--- a/tango_simlib/tango_sim_generator.py
+++ b/tango_simlib/tango_sim_generator.py
@@ -255,7 +255,7 @@ def get_tango_device_server(models, sim_data_files):
     for quantity_name, quantity in list(itervalues(models))[0].sim_quantities.items():
         d_type = str(quantity.meta["data_type"])
         d_format = str(quantity.meta["data_format"])
-        if d_type == "DevEnum" or d_format == "SPECTRUM":
+        if d_type == "DevEnum" or d_format in ("SPECTRUM", "IMAGE"):
             add_static_attribute(
                 TangoDeviceServerStaticAttrs, quantity_name, quantity.meta
             )
@@ -349,10 +349,7 @@ def get_tango_device_server(models, sim_data_files):
         def _is_attribute_addable_dynamically(self, quantity_meta_data):
             attr_dtype = quantity_meta_data["data_type"]
             d_format = quantity_meta_data["data_format"]
-            if str(attr_dtype) == "DevEnum" or str(d_format) == "SPECTRUM":
-                return False
-            elif str(d_format) == "IMAGE":
-                self._not_added_attributes.append(quantity_meta_data["name"])
+            if str(attr_dtype) == "DevEnum" or str(d_format) in ("SPECTRUM", "IMAGE"):
                 return False
 
             return True
@@ -405,7 +402,9 @@ def get_tango_device_server(models, sim_data_files):
                 else:
                     MODULE_LOGGER.debug(
                         "UserDefaultAttrProp has no attribute named '%s' "
-                        "for the device attribute '%s'.", prop, attribute_name,
+                        "for the device attribute '%s'.",
+                        prop,
+                        attribute_name,
                     )
 
             attribute.set_default_properties(attribute_properties)

--- a/tango_simlib/tests/config_files/Spectrum_Image.fgo
+++ b/tango_simlib/tests/config_files/Spectrum_Image.fgo
@@ -1,0 +1,195 @@
+{
+    "attributes": {
+        "image1": {
+            "alarms": {
+                "delta_t": "Not specified",
+                "delta_val": "Not specified",
+                "extensions": "[]",
+                "max_alarm": "Not specified",
+                "max_warning": "Not specified",
+                "min_alarm": "Not specified",
+                "min_warning": "Not specified"
+            },
+            "data_format": "IMAGE",
+            "data_type": "DevDouble",
+            "description": "",
+            "display_unit": "No display unit",
+            "enum_labels": [],
+            "events": {
+                "arch_event": {
+                    "archive_abs_change": "Not specified",
+                    "archive_period": "Not specified",
+                    "archive_rel_change": "Not specified",
+                    "extensions": "[]"
+                },
+                "ch_event": {
+                    "abs_change": "Not specified",
+                    "extensions": "[]",
+                    "rel_change": "Not specified"
+                },
+                "per_event": {
+                    "extensions": "[]",
+                    "period": "100"
+                }
+            },
+            "label": "image1",
+            "max_alarm": "Not specified",
+            "max_dim_x": 6,
+            "max_dim_y": 6,
+            "max_value": "Not specified",
+            "min_alarm": "Not specified",
+            "min_value": "Not specified",
+            "name": "image1",
+            "polling": 1000,
+            "quality": "ATTR_VALID",
+            "standard_unit": "No standard unit",
+            "unit": "",
+            "writable": "READ"
+        },
+        "doubleSpectrum": {
+            "alarms": {
+                "delta_t": "Not specified",
+                "delta_val": "Not specified",
+                "extensions": "[]",
+                "max_alarm": "Not specified",
+                "max_warning": "Not specified",
+                "min_alarm": "Not specified",
+                "min_warning": "Not specified"
+            },
+            "data_format": "SPECTRUM",
+            "data_type": "DevDouble",
+            "description": "",
+            "display_unit": "No display unit",
+            "enum_labels": [],
+            "events": {
+                "arch_event": {
+                    "archive_abs_change": "Not specified",
+                    "archive_period": "Not specified",
+                    "archive_rel_change": "Not specified",
+                    "extensions": "[]"
+                },
+                "ch_event": {
+                    "abs_change": "Not specified",
+                    "extensions": "[]",
+                    "rel_change": "Not specified"
+                },
+                "per_event": {
+                    "extensions": "[]",
+                    "period": "100"
+                }
+            },
+            "label": "doubleSpectrum",
+            "max_alarm": "Not specified",
+            "max_dim_x": 6,
+            "max_dim_y": 0,
+            "max_value": "Not specified",
+            "min_alarm": "Not specified",
+            "min_value": "Not specified",
+            "name": "doubleSpectrum",
+            "polling": 1000,
+            "quality": "ATTR_VALID",
+            "standard_unit": "No standard unit",
+            "unit": "",
+            "writable": "READ"
+        },
+        "booleanSpectrum": {
+            "alarms": {
+                "delta_t": "Not specified",
+                "delta_val": "Not specified",
+                "extensions": "[]",
+                "max_alarm": "Not specified",
+                "max_warning": "Not specified",
+                "min_alarm": "Not specified",
+                "min_warning": "Not specified"
+            },
+            "data_format": "SPECTRUM",
+            "data_type": "DevBoolean",
+            "description": "",
+            "display_unit": "No display unit",
+            "enum_labels": [],
+            "events": {
+                "arch_event": {
+                    "archive_abs_change": "Not specified",
+                    "archive_period": "Not specified",
+                    "archive_rel_change": "Not specified",
+                    "extensions": "[]"
+                },
+                "ch_event": {
+                    "abs_change": "Not specified",
+                    "extensions": "[]",
+                    "rel_change": "Not specified"
+                },
+                "per_event": {
+                    "extensions": "[]",
+                    "period": "100"
+                }
+            },
+            "label": "booleanSpectrum",
+            "max_alarm": "Not specified",
+            "max_dim_x": 6,
+            "max_dim_y": 0,
+            "max_value": "Not specified",
+            "min_alarm": "Not specified",
+            "min_value": "Not specified",
+            "name": "booleanSpectrum",
+            "polling": 1000,
+            "quality": "ATTR_VALID",
+            "standard_unit": "No standard unit",
+            "unit": "",
+            "writable": "READ"
+        },
+        "stringSpectrum": {
+            "alarms": {
+                "delta_t": "Not specified",
+                "delta_val": "Not specified",
+                "extensions": "[]",
+                "max_alarm": "Not specified",
+                "max_warning": "Not specified",
+                "min_alarm": "Not specified",
+                "min_warning": "Not specified"
+            },
+            "data_format": "SPECTRUM",
+            "data_type": "DevString",
+            "description": "",
+            "display_unit": "No display unit",
+            "enum_labels": [],
+            "events": {
+                "arch_event": {
+                    "archive_abs_change": "Not specified",
+                    "archive_period": "Not specified",
+                    "archive_rel_change": "Not specified",
+                    "extensions": "[]"
+                },
+                "ch_event": {
+                    "abs_change": "Not specified",
+                    "extensions": "[]",
+                    "rel_change": "Not specified"
+                },
+                "per_event": {
+                    "extensions": "[]",
+                    "period": "100"
+                }
+            },
+            "label": "stringSpectrum",
+            "max_alarm": "Not specified",
+            "max_dim_x": 6,
+            "max_dim_y": 0,
+            "max_value": "Not specified",
+            "min_alarm": "Not specified",
+            "min_value": "Not specified",
+            "name": "stringSpectrum",
+            "polling": 1000,
+            "quality": "ATTR_VALID",
+            "standard_unit": "No standard unit",
+            "unit": "",
+            "writable": "READ"
+        }
+    },
+    "class_properties": {
+    },
+    "commands": {
+    },
+    "dev_class": "FgoDevice",
+    "properties": {
+    }
+}

--- a/tango_simlib/tests/config_files/Spectrum_SimDD.json
+++ b/tango_simlib/tests/config_files/Spectrum_SimDD.json
@@ -60,6 +60,26 @@
             "period": 1000
           }
         }
+      },
+      {
+        "basicAttributeData": {
+          "name": "image1",
+          "label": "image",
+          "description": "image",
+          "data_type": "Double",
+          "data_format": "Image",
+          "data_shape": {
+            "max_dim_x": 8,
+            "max_dim_y": 4
+          },
+          "dataSimulationParameters": {
+            "quantity_simulation_type": "ConstantQuantity"
+          },
+          "attributeControlSystem": {
+            "display_level": "OPERATOR",
+            "period": 1000
+          }
+        }
       }
     ]
 }

--- a/tango_simlib/tests/test_fandango_json_parser.py
+++ b/tango_simlib/tests/test_fandango_json_parser.py
@@ -19,7 +19,7 @@ import tango
 
 from katcp.testutils import start_thread_with_cleanup
 from tango.test_context import DeviceTestContext
-from tango_simlib import model, tango_sim_generator
+from tango_simlib import tango_sim_generator
 
 from tango_simlib.utilities import fandango_json_parser
 from tango_simlib.utilities.testutils import cleanup_tempfile, ClassCleanupUnittestMixin

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -285,20 +285,20 @@ class test_SimXmiDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase)
         """Test whether the attributes specified in the POGO generated xmi file
         are added to the TANGO device
         """
-        # First testing that the attribute with data format "IMAGE" is not in the device.
+        # First testing that the attribute with data format "IMAGE" is in the device.
         attribute_name = "image1"
         device_attributes = set(self.device.get_attribute_list())
-        self.assertNotIn(
+        self.assertIn(
             attribute_name,
             device_attributes,
             "The attribute {} has been added to the device.".format(attribute_name),
         )
         not_added_attr = self.device.read_attribute("AttributesNotAdded")
-        not_added_attr_names = not_added_attr.value
-        self.assertIn(
+        not_added_attr_names = not_added_attr.value if not_added_attr.value else []
+        self.assertNotIn(
             attribute_name,
             not_added_attr_names,
-            "The attribute {} was not added to the list of attributes that"
+            "The attribute {} was added to the list of attributes that"
             " could not be added to the device.".format(attribute_name),
         )
 
@@ -312,12 +312,21 @@ class test_SimXmiDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase)
             attributes - default_attributes,
             "Actual tango device attribute list differs from expected " "list!",
         )
+    
+    def test_image_attribute_readable(self):
+        attribute_name = "image1"
+        attribute_config = self.device.get_attribute_config(attribute_name)
+        self.assertEqual(attribute_config.data_type, tango.DevDouble)
+        self.assertEqual(attribute_config.data_format, tango.AttrDataFormat.IMAGE)
+        self.assertIsInstance(
+            self.device.read_attribute(attribute_name), tango.DeviceAttribute
+        )
 
     def test_attribute_properties(self):
         attribute_list = self.device.get_attribute_list()
         attribute_data = self.xmi_parser.get_device_attribute_metadata()
         not_added_attr = self.device.read_attribute("AttributesNotAdded")
-        not_added_attr_names = not_added_attr.value
+        not_added_attr_names = not_added_attr.value if not_added_attr.value else []
 
         for attr_name, attr_metadata in attribute_data.items():
             if attr_name in not_added_attr_names:
@@ -381,6 +390,11 @@ class test_SimXmiDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase)
                 # and DevEnum it uses '%s'.
                 if attr_parameter in ["format"]:
                     attr_prop_value = ""
+
+                # Period for image type attribute seems be initialiezed to 1000 even
+                # when the value in the config is different.
+                if attr_name == "image1"  and attr_parameter == "period":
+                    continue
 
                 self.assertEqual(
                     expected_attr_value,

--- a/tango_simlib/tests/test_sim_xmi_parser.py
+++ b/tango_simlib/tests/test_sim_xmi_parser.py
@@ -312,7 +312,7 @@ class test_SimXmiDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase)
             attributes - default_attributes,
             "Actual tango device attribute list differs from expected " "list!",
         )
-    
+
     def test_image_attribute_readable(self):
         attribute_name = "image1"
         attribute_config = self.device.get_attribute_config(attribute_name)
@@ -393,7 +393,7 @@ class test_SimXmiDeviceIntegration(ClassCleanupUnittestMixin, unittest.TestCase)
 
                 # Period for image type attribute seems be initialiezed to 1000 even
                 # when the value in the config is different.
-                if attr_name == "image1"  and attr_parameter == "period":
+                if attr_name == "image1" and attr_parameter == "period":
                     continue
 
                 self.assertEqual(

--- a/tango_simlib/tests/test_simdd_json_parser.py
+++ b/tango_simlib/tests/test_simdd_json_parser.py
@@ -909,7 +909,7 @@ class test_XmiSimddSupplementaryDeviceIntegration(
                     )
 
 
-class test_SimdddSpectrumAttributeDevice(ClassCleanupUnittestMixin, unittest.TestCase):
+class test_SimdddComplexAttributeDevice(ClassCleanupUnittestMixin, unittest.TestCase):
     """A test class that tests the simdd file for SPECTRUM attribute."""
 
     longMessage = True
@@ -938,7 +938,7 @@ class test_SimdddSpectrumAttributeDevice(ClassCleanupUnittestMixin, unittest.Tes
             start_thread_with_cleanup(cls, cls.tango_context)
 
     def setUp(self):
-        super(test_SimdddSpectrumAttributeDevice, self).setUp()
+        super(test_SimdddComplexAttributeDevice, self).setUp()
         self.device = self.tango_context.device
 
     def test_spectrum_attributes_are_readable(self):
@@ -954,3 +954,12 @@ class test_SimdddSpectrumAttributeDevice(ClassCleanupUnittestMixin, unittest.Tes
             self.assertIsInstance(
                 self.device.read_attribute(attribute_name), tango.DeviceAttribute
             )
+
+    def test_image_attribute_readable(self):
+        attribute_name = "image1"
+        attribute_config = self.device.get_attribute_config(attribute_name)
+        self.assertEqual(attribute_config.data_type, tango.DevDouble)
+        self.assertEqual(attribute_config.data_format, tango.AttrDataFormat.IMAGE)
+        self.assertIsInstance(
+            self.device.read_attribute(attribute_name), tango.DeviceAttribute
+        )

--- a/tango_simlib/tests/test_tango_sim_generator.py
+++ b/tango_simlib/tests/test_tango_sim_generator.py
@@ -192,17 +192,17 @@ class test_XmiFile(BaseTest.TangoSimGenDeviceIntegration):
         """Testing whether the attributes specified in the POGO generated XMI file
         are added to the TANGO device.
         """
-        # First testing that the attribute with data format "IMAGE" is not in the device.
+        # First testing that the attribute with data format "IMAGE" is in the device.
         attribute_name = "image1"
         device_attributes = set(self.sim_device.get_attribute_list())
-        self.assertNotIn(
+        self.assertIn(
             attribute_name,
             device_attributes,
             "The attribute {} has been added to the device.".format(attribute_name),
         )
         not_added_attr = self.sim_device.read_attribute("AttributesNotAdded")
-        not_added_attr_names = not_added_attr.value
-        self.assertIn(
+        not_added_attr_names = not_added_attr.value if not_added_attr.value else []
+        self.assertNotIn(
             attribute_name,
             not_added_attr_names,
             "The attribute {} was not added to the list of attributes that"
@@ -356,7 +356,7 @@ class test_TangoSimGenerator(BaseTest.TangoSimGenDeviceIntegration):
         """Test that the TANGO device Init command works correctly."""
         default_val = 0
         self.assertEqual(self.sim_device.integer1, default_val)
-        # Write to the attribute desiredPointing
+        # Write to the attribute integer1
         self.sim_device.integer1 = 45
         self.assertEqual(self.sim_device.integer1, 45)
         # Reset the values of the device attributes to default.

--- a/tango_simlib/tests/test_yaml_builder.py
+++ b/tango_simlib/tests/test_yaml_builder.py
@@ -52,7 +52,7 @@ def test_file_builders_xmi():
     for attr in parsed_yaml[0]["meta"]["attributes"]:
         if attr["name"] == "band4CapabilityState":
             assert attr == {
-                "enum_labels": ["INIT", "OFF", "ON"],
+                "enum_labels": ["INIT", "ON", "OFF"],
                 "description": "The band 4 capability state of the DSH Element.",
                 "data_type": "DevEnum",
                 "max_value": "2",

--- a/tango_simlib/utilities/sim_xmi_parser.py
+++ b/tango_simlib/utilities/sim_xmi_parser.py
@@ -325,7 +325,7 @@ class XmiParser(Parser):
             for child in description_data.getchildren():
                 if child.tag == "enumLabels":
                     enum_labels.append(child.text)
-            attribute_data["dynamicAttributes"]["enum_labels"] = sorted(enum_labels)
+            attribute_data["dynamicAttributes"]["enum_labels"] = enum_labels
 
         attribute_data["properties"] = description_data.find("properties").attrib
         attribute_data["properties"]["inherited"] = description_data.find(


### PR DESCRIPTION
Previously the library did not support the creation of attributes of data format `IMAGE`. This change enables that. Unit tests are also added to ensure that the attributes are added on the device, and that they are readable.

*Screenshots or code snippets (if appropriate):*
N/A

*Definition of Done Checklist*

- [x] Code meets our [python style guidelines](https://docs.google.com/document/d/1aZoIyR9tz5rCWr2qJKuMTmKp2IzHlFjrCFrpDDHFypM/edit?usp=sharing)?
- [x] Unit tested (coded, passed, included)?
- [x] Requested at least 2 reviewers?
- [x] Commented code, particularly in hard-to-understand areas?
- [x] Made corresponding changes to the documentation (e.g. Python documentation, System Engineering Documentation, version description updates, README file, etc)?

JIRA(SKA): [KAR-422](https://jira.skatelescope.org/browse/KAR-422)
