### PR TITLE
Generate simulation data for SPECTRUM/IMAGE attributes

### DIFF
--- a/tango_simlib/model.py
+++ b/tango_simlib/model.py
@@ -266,7 +266,10 @@ class Model(object):
                         adjustable_val = get_default_quantity_value(quantity_metadata)
                     else:
                         if adjustable_attr == "last_val":
-                            quantity.last_val = float(quantity_metadata["mean"])
+                            mean = float(quantity_metadata["mean"])
+                            quantity.last_val = (
+                                quantity.compute_initial_value(quantity_metadata, mean)
+                            )
                             continue
                         else:
                             adjustable_val = float(quantity_metadata[adjustable_attr])

--- a/tango_simlib/quantities.py
+++ b/tango_simlib/quantities.py
@@ -146,7 +146,8 @@ class GaussianSlewLimited(Quantity):
         start_value=None,
         start_time=None,
     ):
-        start_value = start_value if start_value is not None else mean
+        if not start_value:
+            start_value = self.compute_initial_value(meta, mean)
         super(GaussianSlewLimited, self).__init__(
             start_value=start_value, start_time=start_time, meta=meta
         )
@@ -156,7 +157,20 @@ class GaussianSlewLimited(Quantity):
         self.max_slew_rate = max_slew_rate
         self.min_bound = min_bound
         self.max_bound = max_bound
-        self.last_val = mean
+        self.last_val = start_value
+
+    def compute_initial_value(self, meta, mean):
+        data_format = str(meta["data_format"])
+        max_dim_x = int(meta["max_dim_x"])
+        max_dim_y = int(meta["max_dim_y"])
+        initial_value = None
+        if data_format == "SCALAR":
+            initial_value = mean
+        elif data_format == "SPECTRUM":
+            initial_value = [mean] * max_dim_x
+        elif data_format == "IMAGE":
+            initial_value = [[mean] * max_dim_x for i in range(max_dim_y)]
+        return initial_value
 
     def next_val(self, t):
         """Returns the next value of the simulation.
@@ -167,16 +181,36 @@ class GaussianSlewLimited(Quantity):
             Time to update quantity
 
         """
-        dt = t - self.last_update_time
+        delta_time = t - self.last_update_time
+        self.last_val = self._generate_simulation_data(delta_time)
+        self.last_update_time = t
+        return self.last_val
+
+    def compute_next_value(self, dt, value):
         max_slew = self.max_slew_rate * dt
-        new_val = gauss(self.mean, self.std_dev)
-        delta = new_val - self.last_val
+        new_value = gauss(self.mean, self.std_dev)
+        delta = new_value - value
         val = self.last_val + cmp(delta, 0) * min(abs(delta), max_slew)
         val = min(val, self.max_bound)
         val = max(val, self.min_bound)
-        self.last_val = val
-        self.last_update_time = t
         return val
+
+    def _generate_simulation_data(self, delta_time):
+        data_format = str(self.meta["data_format"])
+        max_dim_x = int(self.meta["max_dim_x"])
+        max_dim_y = int(self.meta["max_dim_y"])
+        value = self.last_val
+        if data_format == "SCALAR":
+            value = self.compute_next_value(delta_time, value)
+        elif data_format == "SPECTRUM":
+            for i in range(max_dim_x):
+                value[i] = self.compute_next_value(delta_time, value[i])
+        elif data_format == "IMAGE":
+            for i in range(max_dim_x):
+                for j in range(max_dim_y):
+                    value[i][j] = self.compute_next_value(delta_time, value[i][j])
+
+        return value
 
 
 register_quantity_class(GaussianSlewLimited)

--- a/tango_simlib/quantities.py
+++ b/tango_simlib/quantities.py
@@ -161,8 +161,8 @@ class GaussianSlewLimited(Quantity):
 
     def compute_initial_value(self, meta, mean):
         data_format = str(meta["data_format"])
-        max_dim_x = int(meta["max_dim_x"])
-        max_dim_y = int(meta["max_dim_y"])
+        max_dim_x = int(meta.get("max_dim_x", 1))
+        max_dim_y = int(meta.get("max_dim_y", 0))
         initial_value = None
         if data_format == "SCALAR":
             initial_value = mean
@@ -197,8 +197,8 @@ class GaussianSlewLimited(Quantity):
 
     def _generate_simulation_data(self, delta_time):
         data_format = str(self.meta["data_format"])
-        max_dim_x = int(self.meta["max_dim_x"])
-        max_dim_y = int(self.meta["max_dim_y"])
+        max_dim_x = int(self.meta.get("max_dim_x", 1))
+        max_dim_y = int(self.meta.get("max_dim_y", 0))
         value = self.last_val
         if data_format == "SCALAR":
             value = self.compute_next_value(delta_time, value)

--- a/tango_simlib/tests/config_files/Spectrum_SimDD.json
+++ b/tango_simlib/tests/config_files/Spectrum_SimDD.json
@@ -13,7 +13,13 @@
             "max_dim_y": 0
           },
           "dataSimulationParameters": {
-            "quantity_simulation_type": "ConstantQuantity"
+            "quantity_simulation_type": "GaussianSlewLimited",
+            "min_bound": -10,
+            "max_bound": 50,
+            "mean": 2500,
+            "max_slew_rate": 1,
+            "update_period": 1000,
+            "std_dev": 5
           },
           "attributeControlSystem": {
             "display_level": "OPERATOR",


### PR DESCRIPTION
The `GaussianSlewLimited` quantity class only generated simulation values that are python primitive types (float in this case) which are appropriate for attributes with a SCALAR data format.

This is a problem for the attrbiutes with more complex data formats, `SPECTRUM`/`IMAGE`. When reading an attribute, the quantity returns a primitive type which PyTango is not expecting, therefore resulting in the error, `Wrong Python type for attribute... Expected a sequence`. This change here allows us to cater for the complex data formats. The method `next_val` now generates the simulation data according to the data format, given by the `meta` dictionary.

Resolves #157

Signed-off-by: Katleho Madisa <katleho.madisa47@gmail.com>

*Screenshots or code snippets (if appropriate):*
N/A

*Definition of Done Checklist*

- [ ] Code meets our [python style guidelines](https://docs.google.com/document/d/1aZoIyR9tz5rCWr2qJKuMTmKp2IzHlFjrCFrpDDHFypM/edit?usp=sharing)?
- [ ] Unit tested (coded, passed, included)?
- [ ] Requested at least 2 reviewers?
- [ ] Commented code, particularly in hard-to-understand areas?
- [ ] Made corresponding changes to the documentation (e.g. Python documentation, System Engineering Documentation, version description updates, README file, etc)?

SKA-JIRA: [442](https://jira.skatelescope.org/browse/KAR-442)
